### PR TITLE
Grant remote clients parity with desktop for Host operations

### DIFF
--- a/docs/adr/0003-data-ownership-and-remote-security.md
+++ b/docs/adr/0003-data-ownership-and-remote-security.md
@@ -20,13 +20,12 @@ settings use native RPC; project and global defaults atomically merge into Pi se
 unknown keys.
 
 Remote pairing is QR-only. A single-use pairing token expires after five minutes and exchanges for a
-revocable long-term device token; only its hash is persisted. Remote clients may use approved runtime
-operations but cannot invoke folder picking, app launching, package changes, updates, workspace
-deletion, or other dangerous Host operations.
-The `/picot-config` prompt adapter can mutate Pi-owned settings and historical session metadata; as of
-2026, remote clients paired via QR are trusted to invoke it like desktop clients, so the Host router no
-longer special-cases `/picot-config` runtime prompts for `ClientKind::Remote`. The dangerous
-`host_request` operations above remain remote-forbidden.
+revocable long-term device token; only its hash is persisted. A device that completes QR pairing is
+trusted to the same degree as the desktop app: as of 2026-08, the Host router no longer distinguishes
+`ClientKind::Remote` from `ClientKind::Desktop` for authorization purposes, so a paired mobile/LAN
+client has parity with desktop for Host operations (folder picking, app launching, package and Pi
+package changes, updates, workspace deletion, `/picot-config`) and for local Git operations. The
+`ClientKind` distinction is retained only for identity/telemetry, not for gating.
 
 The LAN transport remains unencrypted for this release. The product must display an explicit warning
 that prompts and source may be observable on the network.

--- a/public/terminal-panel.js
+++ b/public/terminal-panel.js
@@ -1,6 +1,6 @@
-// ABOUTME: Native-owner-only Terminal Panel: DOM, tab bar, collapse/expand,
-// ABOUTME: height clamp, workspace checkpoint/reattach, and close-risk participant.
-// ABOUTME: Remote/LAN/mobile clients render no terminal surface at all.
+// ABOUTME: Terminal Panel: DOM, tab bar, collapse/expand, height clamp,
+// ABOUTME: workspace checkpoint/reattach, and close-risk participant.
+// ABOUTME: Rendered for desktop and remote/LAN/mobile clients alike.
 
 import { t } from "./i18n.js";
 

--- a/src-tauri/src/host_router.rs
+++ b/src-tauri/src/host_router.rs
@@ -5,27 +5,6 @@ use std::collections::HashMap;
 
 pub const PROTOCOL_VERSION: u64 = 2;
 
-const REMOTE_FORBIDDEN_HOST_OPERATIONS: &[&str] = &[
-    "pick_folder",
-    "open_app",
-    "install_package",
-    "remove_package",
-    "install_pi_package",
-    "remove_pi_package",
-    "update_pi_package",
-    "set_pi_package_disabled",
-    "restart_runtime",
-    "update_package",
-    "check_for_updates",
-    "install_update",
-    "delete_workspace",
-    "open_workspace",
-    "delete_sessions",
-    "pick_skill_source",
-    "skill_scan_install_source",
-    "skill_install_links",
-];
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClientKind {
     Desktop,
@@ -138,7 +117,7 @@ impl HostRouter {
     }
 
     pub fn route(&self, client_id: &str, frame: &Value) -> Result<RoutedAction, RouterError> {
-        let client_kind = self.client_kind(client_id).ok_or_else(|| {
+        self.client_kind(client_id).ok_or_else(|| {
             RouterError::new("unauthorized_client", "Client has not completed handshake")
         })?;
         let frame_type = frame
@@ -154,12 +133,6 @@ impl HostRouter {
 
         match frame_type {
             "git_command" | "git_ai_commit_message" => {
-                if client_kind != ClientKind::Desktop {
-                    return Err(RouterError::new(
-                        "remote_operation_forbidden",
-                        "Remote clients cannot use local Git operations",
-                    ));
-                }
                 if frame.get("workspaceId").and_then(Value::as_str).is_none() {
                     return Err(RouterError::new(
                         "invalid_git_command",
@@ -216,14 +189,6 @@ impl HostRouter {
                         .ok_or_else(|| {
                             RouterError::new("invalid_host_request", "operation is required")
                         })?;
-                if client_kind == ClientKind::Remote
-                    && REMOTE_FORBIDDEN_HOST_OPERATIONS.contains(&operation)
-                {
-                    return Err(RouterError::new(
-                        "remote_operation_forbidden",
-                        "Remote clients cannot invoke this Host operation",
-                    ));
-                }
                 Ok(RoutedAction::Host {
                     client_id: client_id.to_owned(),
                     request_id,
@@ -377,7 +342,7 @@ mod tests {
     }
 
     #[test]
-    fn forbids_dangerous_host_operations_for_remote_clients() {
+    fn allows_previously_dangerous_host_operations_for_remote_clients() {
         let mut router = HostRouter::new();
         router
             .connect(
@@ -403,8 +368,28 @@ mod tests {
                         "operation": operation,
                     }),
                 )
-                .is_err());
+                .is_ok());
         }
+    }
+
+    #[test]
+    fn allows_git_commands_for_remote_clients() {
+        let mut router = HostRouter::new();
+        router
+            .connect(
+                "phone",
+                &json!({ "type": "hello", "protocolVersion": 2, "clientType": "remote" }),
+            )
+            .unwrap();
+        let command = router.route(
+            "phone",
+            &json!({
+                "type": "git_command",
+                "requestId": "git-1",
+                "workspaceId": "workspace-a",
+            }),
+        );
+        assert!(matches!(command, Ok(RoutedAction::Git { .. })));
     }
 
     #[test]

--- a/src-tauri/src/host_server.rs
+++ b/src-tauri/src/host_server.rs
@@ -895,13 +895,6 @@ async fn handle_websocket(mut socket: WebSocket, state: Arc<HostState>) {
         return;
     }
     let terminal_owner = OwnerId::from_client_id(&client_id);
-    let desktop_owner = state
-        .router
-        .lock()
-        .ok()
-        .and_then(|router| router.client_kind(&client_id))
-        .filter(|kind| *kind == crate::host_router::ClientKind::Desktop)
-        .map(|_| OwnerId::from_client_id(&client_id));
     if socket
         .send(Message::Text(
             json!({ "type": "hello_ack", "protocolVersion": PROTOCOL_VERSION })
@@ -1030,7 +1023,7 @@ async fn handle_websocket(mut socket: WebSocket, state: Arc<HostState>) {
             }
             event = git_events.recv() => {
                 match event {
-                    Ok((owner, outgoing)) if desktop_owner.as_ref() == Some(&OwnerId::from_client_id(&owner)) => {
+                    Ok((owner, outgoing)) if owner == client_id => {
                         if socket.send(Message::Text(outgoing.to_string().into())).await.is_err() {
                             break;
                         }


### PR DESCRIPTION
## Summary
This change removes authorization restrictions that previously prevented remote clients from invoking certain Host operations and Git commands. After QR pairing, remote clients are now trusted to the same degree as desktop clients.

## Key Changes
- **Removed forbidden operations list**: Deleted `REMOTE_FORBIDDEN_HOST_OPERATIONS` constant that blocked remote clients from folder picking, app launching, package management, updates, workspace deletion, and other operations
- **Removed Git operation restrictions**: Remote clients can now invoke `git_command` and `git_ai_commit_message` operations (previously desktop-only)
- **Simplified authorization logic**: Removed client kind checks in the router that returned "remote_operation_forbidden" errors
- **Updated WebSocket handler**: Changed Git event filtering from checking `desktop_owner` to directly comparing `owner == client_id`, eliminating the desktop-only distinction
- **Updated terminal panel**: Modified comments to reflect that terminal surface is now rendered for both desktop and remote/LAN/mobile clients
- **Updated ADR documentation**: Clarified that as of 2026-08, `ClientKind` distinction is retained only for identity/telemetry purposes, not for authorization gating

## Implementation Details
The changes maintain the `ClientKind` enum distinction between Desktop and Remote for identity and telemetry tracking, but remove all authorization gates that previously used this distinction. This reflects the security model where QR pairing establishes sufficient trust for parity with desktop clients.

Test updates confirm the new behavior:
- Renamed test to `allows_previously_dangerous_host_operations_for_remote_clients` 
- Added new test `allows_git_commands_for_remote_clients` to verify Git operations work for remote clients

https://claude.ai/code/session_01UWHPbYqTXfWMT52qgMmrmg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote devices can now perform the same authorized host actions as desktop clients, including folder selection, app launching, package changes, updates, workspace deletion, configuration changes, and local Git operations.
  * Remote, LAN, and mobile connections can now display and use the terminal panel.
  * Terminal and Git activity is delivered consistently to the connected client.

* **Bug Fixes**
  * Removed restrictions that incorrectly blocked remote devices from supported host operations and Git commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->