### PR TITLE
feat: add extension command and custom UI parity analysis between pi-…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
           - os: macos-14
             pi_target_platform: darwin-x64
             rust_target: x86_64-apple-darwin
-          # Linux deb/rpm bundling is currently more stable on 22.04 than
-          # 24.04 for GTK/WebKit bundles in CI.
+          # Linux deb/rpm/AppImage bundling is currently more stable on
+          # 22.04 than 24.04 for GTK/WebKit bundles in CI.
           - os: ubuntu-22.04
             pi_target_platform: linux-x64
           - os: ubuntu-24.04-arm
@@ -84,6 +84,15 @@ jobs:
           if ! apt-cache show "$WEBKIT_DEV_PKG" >/dev/null 2>&1; then
             WEBKIT_DEV_PKG="libwebkit2gtk-4.0-dev"
           fi
+          # Ubuntu 24.04 renamed libfuse2 -> libfuse2t64 (64-bit time_t ABI
+          # transition). AppImages need FUSE (or the extract-and-run runtime
+          # fallback) to execute themselves; installing it explicitly rules
+          # out "missing libfuse.so.2" as a cause of AppImage bundling
+          # failures on the ubuntu-24.04-arm runner.
+          FUSE_PKG="libfuse2t64"
+          if ! apt-cache show "$FUSE_PKG" >/dev/null 2>&1; then
+            FUSE_PKG="libfuse2"
+          fi
           sudo apt-get install -y \
             desktop-file-utils \
             "$WEBKIT_DEV_PKG" \
@@ -93,7 +102,8 @@ jobs:
             gstreamer1.0-plugins-base \
             gstreamer1.0-plugins-good \
             rpm \
-            patchelf
+            patchelf \
+            "$FUSE_PKG"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -132,11 +142,15 @@ jobs:
       - name: Build pi extensions bundle
         run: bun run build:extensions
 
-      - name: Build Tauri app (Linux deb + rpm) and publish assets
+      - name: Build Tauri app (Linux deb + rpm + AppImage) and publish assets
         if: runner.os == 'Linux'
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPIMAGE_EXTRACT_AND_RUN: 1
+          # Workaround for linuxdeploy/strip failures on modern ELF
+          # binaries (e.g. `.relr.dyn`), see tauri#14796.
+          NO_STRIP: "true"
           # Signing key for the Tauri updater. Required so the bundler
           # produces `*.sig` files and `latest.json` (the manifest the
           # auto-updater reads from the GitHub release). Configure these
@@ -152,7 +166,10 @@ jobs:
             Download the installer for your platform from the assets below.
           releaseDraft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
-          args: --bundles deb,rpm
+          # --verbose: if this still fails, we need linuxdeploy's actual
+          # stderr instead of tauri-bundler's generic "failed to run
+          # linuxdeploy" wrapper error.
+          args: --bundles deb,rpm,appimage --verbose
           # tauri-action will only attach `latest.json` (the updater
           # manifest) when this is `true`. Combined with
           # `bundle.createUpdaterArtifacts` in tauri.conf.json, the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
           - os: macos-14
             pi_target_platform: darwin-x64
             rust_target: x86_64-apple-darwin
-          # Linux deb/rpm/AppImage bundling is currently more stable on 22.04
-          # than 24.04 for GTK/WebKit bundles in CI.
+          # Linux deb/rpm bundling is currently more stable on 22.04 than
+          # 24.04 for GTK/WebKit bundles in CI.
           - os: ubuntu-22.04
             pi_target_platform: linux-x64
           - os: ubuntu-24.04-arm
@@ -132,15 +132,11 @@ jobs:
       - name: Build pi extensions bundle
         run: bun run build:extensions
 
-      - name: Build Tauri app (Linux deb + rpm + AppImage) and publish assets
+      - name: Build Tauri app (Linux deb + rpm) and publish assets
         if: runner.os == 'Linux'
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPIMAGE_EXTRACT_AND_RUN: 1
-          # Workaround for linuxdeploy/strip failures on modern ELF
-          # binaries (e.g. `.relr.dyn`), see tauri#14796.
-          NO_STRIP: "true"
           # Signing key for the Tauri updater. Required so the bundler
           # produces `*.sig` files and `latest.json` (the manifest the
           # auto-updater reads from the GitHub release). Configure these
@@ -156,7 +152,7 @@ jobs:
             Download the installer for your platform from the assets below.
           releaseDraft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
-          args: --bundles deb,rpm,appimage
+          args: --bundles deb,rpm
           # tauri-action will only attach `latest.json` (the updater
           # manifest) when this is `true`. Combined with
           # `bundle.createUpdaterArtifacts` in tauri.conf.json, the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
           - os: macos-14
             pi_target_platform: darwin-x64
             rust_target: x86_64-apple-darwin
-          # Linux deb/rpm bundling is currently more stable on 22.04 than
-          # 24.04 for GTK/WebKit bundles in CI.
+          # Linux deb/rpm/AppImage bundling is currently more stable on 22.04
+          # than 24.04 for GTK/WebKit bundles in CI.
           - os: ubuntu-22.04
             pi_target_platform: linux-x64
           - os: ubuntu-24.04-arm
@@ -132,7 +132,7 @@ jobs:
       - name: Build pi extensions bundle
         run: bun run build:extensions
 
-      - name: Build Tauri app (Linux deb + rpm) and publish assets
+      - name: Build Tauri app (Linux deb + rpm + AppImage) and publish assets
         if: runner.os == 'Linux'
         uses: tauri-apps/tauri-action@v0
         env:
@@ -156,7 +156,7 @@ jobs:
             Download the installer for your platform from the assets below.
           releaseDraft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
-          args: --bundles deb,rpm
+          args: --bundles deb,rpm,appimage
           # tauri-action will only attach `latest.json` (the updater
           # manifest) when this is `true`. Combined with
           # `bundle.createUpdaterArtifacts` in tauri.conf.json, the

--- a/docs/extension-ui-parity-pi-web-vs-picot.md
+++ b/docs/extension-ui-parity-pi-web-vs-picot.md
@@ -1,0 +1,351 @@
+# Extension Command / Custom UI Parity: pi-web vs Picot
+
+Comparison of how the two web-facing hosts talk to the same underlying protocol
+(`pi --mode rpc`, defined in `pi-mono/packages/coding-agent/src/modes/rpc/`) and
+why Picot currently loses a class of extension functionality that pi-web
+supports.
+
+## 1. How the two hosts attach to the RPC protocol
+
+| | **pi-web** | **Picot** |
+|---|---|---|
+| Runtime | Embeds `@earendil-works/pi-coding-agent` **in-process** via the SDK (`createAgentSessionFromServices`, `AgentSessionWrapper` in `lib/rpc-manager.ts`) | Spawns the real `pi` binary as a **subprocess** with `--mode rpc` (`src-tauri/src/native_pi_manager.rs:44`, `--mode rpc`) and talks to it over stdin/stdout JSONL (`pi_rpc_bridge.rs`) |
+| Extension binding | Calls `session.bindExtensions({ uiContext, mode: "rpc", commandContextActions, ... })` directly with a **JS object** implementing `ExtensionUIContext` — no serialization | Extensions run inside the child `pi` process and talk to *its own* RPC layer (`rpc-mode.ts`), which serializes `ExtensionUIContext` calls into `extension_ui_request` JSON frames on stdout |
+| Transport to browser | Same-process event emitter (`AgentEvent`) → SSE/WebSocket to the React client | JSON frames from the child process → Rust `PiRpcBridge` → forwarded verbatim over the Tauri WebSocket/host origin to the JS frontend |
+
+Both ultimately expose the **same wire protocol** (`extension_ui_request` /
+`extension_ui_response`, `get_commands`, etc., defined in `rpc-types.ts`). The
+difference is not the protocol — it's how much of that protocol each frontend
+actually *implements*.
+
+## 2. Command execution (`get_commands`, slash commands)
+
+Both sides call `{ type: "get_commands" }` and get back
+`{ commands: RpcSlashCommand[] }` (extension-registered commands + prompt
+templates + skills). Both build a slash-command palette from it:
+
+- pi-web: `components/ChatInput.tsx` (`buildSlashCommandLayout`, grouped by
+  source: builtin/extension/prompt/skill).
+- Picot: `public/native/composer/slash-commands.js` (`buildCommandCatalog`) +
+  `public/native/composer/composer-slash-menu.js`, fed from
+  `app.js:640-645` (`loadCommands()` → `runtime.request({ type: "get_commands" }, target)`;
+  moved from the old `app.js:611` call site, same behavior).
+
+**This part is at parity.** Invoking a command just sends a `prompt`/`steer`
+RPC command in both cases; the command's *side effects* (tool calls, message
+history) render fine everywhere because they flow through the normal message
+stream, not through `ExtensionUIContext`.
+
+The gap is entirely in what happens **while** a command/extension is running
+and wants to render or read something outside the normal chat transcript.
+
+## 3. Extension UI methods — implementation matrix
+
+`ExtensionUIContext` (`pi-mono/.../core/extensions/types.ts:124`) has ~20
+methods. Each one becomes an `extension_ui_request` frame with a `method`
+field. Here is what each frontend does with it:
+
+| method | RPC frame | pi-web (`lib/rpc-manager.ts`, `hooks/useAgentSession.ts`, `components/ChatWindow.tsx`) | Picot (`extension-ui-host.js`, `app.js`, `dialog.js`) |
+|---|---|---|---|
+| `select` / `confirm` / `input` / `editor` | blocking, needs `extension_ui_response` | ✅ Rendered as a modal (`ExtensionDialog`) built from React | ✅ Rendered as a modal (`showNativeDialog`) or inline card (`showInlineExtensionPrompt`), queued per-session |
+| `notify` | fire-and-forget | ✅ `addNotice` → toast/system message | ✅ `messageRenderer.renderSystemMessage` |
+| `setStatus` | fire-and-forget | ✅ `ExtensionStatusBar` renders `{key,text}` pills | ✅ shown only as generic "Connected" text (`setStatus(request.statusText || "Connected")`) — status **key** is discarded, so multiple concurrent statuses collapse to one string |
+| `setWidget` (string[] content only) | fire-and-forget | ✅ `ExtensionWidgets` renders `lines[]` above/below the editor, keyed by `widgetKey`, keeps a live `Map<key, widget>` | ⚠️ **Special-cased for exactly one extension** (`rpiv-todo-mirror.js` matches `widgetKey === "rpiv-todos"`); every other extension's widget hits the hook and is silently dropped (`widget: (request) => { if (isRpivTodoWidgetRequest(request)) return; }` — no `else` branch) |
+| `setWidget` (component-factory overload) | **not representable over RPC at all** | Not supported (RPC mode strips factories, see `rpc-mode.ts` comment: *"Only support string arrays in RPC mode — factory functions are ignored"*) | Same limitation — this is a protocol-level gap, not host-specific |
+| `setTitle` | fire-and-forget | ✅ sets `document.title` | ✅ sets `document.title` |
+| `set_editor_text` / `pasteToEditor` | fire-and-forget | ✅ inserts into the composer via `chatInputRef` | ✅ sets `input.value` directly |
+| `custom(factory, …)` (arbitrary interactive TUI component) | needs `extension_ui_request(method:"custom")` render frames + `extension_ui_input` keystroke frames + `extension_ui_response` on close | ✅ **Full support** — see §4 | ❌ **Explicitly rejected**: `extension-ui-host.js` has no `case "custom"`, falls into `default:` and immediately replies `{ cancelled: true, error: "unsupported" }` |
+| `setWorkingMessage` / `setWorkingVisible` / `setWorkingIndicator` / `setHiddenThinkingLabel` | not emitted at all by RPC mode (`rpc-mode.ts` has them as no-ops with comments: *"not supported in RPC mode - requires TUI loader access"*) | N/A (never sent) | N/A (never sent) |
+| `setFooter` / `setHeader` | not emitted at all in RPC mode (no-ops) | N/A | N/A |
+| `getEditorText` | synchronous, can't round-trip over RPC | returns `""` always | not implemented client-side either |
+| `addAutocompleteProvider` / `setEditorComponent` | not supported over RPC | no-op | no-op |
+| theme methods (`getAllThemes`, `setTheme`, …) | RPC returns empty/failure | stubbed | not surfaced |
+
+**Headline finding:** `setStatus`/`setWidget` are received by Picot's bridge
+but the frontend throws away the payload for anything beyond one hardcoded
+extension, and `custom` is actively refused at the JS layer — even though the
+Rust bridge (`pi_rpc_bridge.rs`) and the runtime frame classification
+(`BridgeFrame::ExtensionUi`) already forward these frames correctly. **The gap
+is 100% in the browser-side JS (`extension-ui-host.js`), not in Rust, not in
+the RPC protocol, and not in the `pi` binary.**
+
+> **Verified 2026-08-02** against current code — all claims above still hold.
+> File locations have moved since this doc was first written:
+> `extension-ui-host.js` now lives at
+> `public/native/extensions/extension-ui-host.js`, and `rpiv-todo-mirror.js`
+> at `public/native/features/rpiv-todo-mirror.js`. The dispatch switch
+> (`extension-ui-host.js:143-169`) still has no `case "custom"` and no
+> `pasteToEditor` case — both fall through to `default:` and reply
+> `{ cancelled: true, error: "unsupported" }`. `hooks.status`/`hooks.widget`
+> in `app.js:265-299` are unchanged: `status` discards `statusKey`
+> (`setStatus(request.statusText || "Connected")`, line 284) and `widget` has
+> no `else` branch beyond the `rpiv-todos` special case (lines 293-297).
+> `pi_rpc_bridge.rs`'s `read_frames()` (lines 279-319) still classifies purely
+> on the `type` field prefix (`extension_ui*`) into `BridgeFrame::ExtensionUi`
+> without ever inspecting `method` — confirming the bridge is not the
+> bottleneck.
+
+## 4. Why pi-web can do `custom()` and Picot can't
+
+`ExtensionUIContext.custom()` lets an extension mount an arbitrary
+interactive component built with `pi-tui` primitives (`Component`, `TUI`,
+`Theme`, `KeybindingsManager`) and get raw keystrokes until it calls `done()`.
+
+### pi-web's trick: a headless TUI shim, in the same process
+
+Because pi-web embeds the SDK in-process, it doesn't need RPC serialization
+for `custom()` at all — it can call the extension's factory function directly
+with a **headless implementation of `TUI`**:
+
+- `lib/custom-ui-terminal.ts` — `createHeadlessCustomUiTui()` returns a fake
+  `{ terminal: { columns, rows, kittyProtocolActive: false }, requestRender() }`
+  that satisfies the `TUI` interface enough for `pi-tui` `Component`s to render
+  themselves into an array of ANSI-styled strings.
+- `lib/rpc-manager.ts` (`requestExtensionCustomUi`) calls
+  `factory(tui, PLAIN_TEXT_THEME, CUSTOM_UI_KEYBINDINGS, done)`, gets back a
+  `Component` with `.render(width): string[]`, and on every `requestRender()`
+  re-invokes `.render()` and emits the resulting lines as
+  `extension_ui_request { method: "custom", lines }`.
+- Because pi-web *is* the RPC endpoint (it's the SDK, not a client of one),
+  this whole flow happens **without ever leaving the module** — no subprocess,
+  no extra IPC frame for the component object itself, only the rendered lines
+  cross into the browser.
+- Keystrokes come back as `extension_ui_input { id, data }` (see
+  `lib/rpc-manager.ts:610`, fed by `hooks/useAgentSession.ts:753`) and are
+  passed to `component.handleInput(data)`, which is exactly what a real
+  terminal would feed a `pi-tui` component (raw ANSI/keyboard escape
+  sequences, produced browser-side by `lib/terminal-input.ts` —
+  `toTerminalKeyData()` / `asBracketedPaste()`).
+- The browser side is `ExtensionCustomPanel` in `components/ChatWindow.tsx`: a
+  modal with a hidden `<textarea>` that captures keydown/composition/paste
+  events, converts them to terminal escape sequences, and a `<pre>` that
+  renders the ANSI-styled lines via `parseAnsiLine()` (`lib/ansi.ts`).
+
+So pi-web effectively reimplements "one terminal cell grid, rendered as HTML,
+fed by real keystrokes" — a minimal xterm-like bridge, purpose-built for
+`pi-tui` components. It does not need `pi-tui`'s real terminal renderer; it
+only needs `Component.render(width): string[]` + `Component.handleInput(data)`,
+which is the full public contract `pi-tui` components implement.
+
+### What's missing for Picot to get the same thing
+
+Picot's architecture already has the right shape to do this — it's arguably
+*better positioned* than pi-web, because:
+
+1. The Rust bridge already classifies `method: "custom"` frames as
+   `BridgeFrame::ExtensionUi` and forwards them — nothing to change there.
+2. `pi_rpc_bridge.rs`'s `request()`/`send_frame()` already round-trip
+   arbitrary JSON, so `extension_ui_input` frames (keystrokes) are just another
+   JSON payload the bridge doesn't need to know about.
+3. Picot already has ANSI-aware rendering infrastructure it built for other
+   things (dialogs, tool cards) that could be reused/extended.
+
+But two pieces are genuinely absent:
+
+1. **The RPC child process itself never emits `method: "custom"` frames**,
+   because `rpc-mode.ts`'s `custom()` implementation is a hard stub:
+   ```ts
+   async custom() {
+     // Custom UI not supported in RPC mode
+     return undefined as never;
+   }
+   ```
+   (still the exact code at `rpc-mode.ts:227-230` as of 2026-08-02; also
+   confirmed `setFooter`/`setHeader`/`setWorkingMessage`/`setWorkingVisible`/
+   `setWorkingIndicator`/`setHiddenThinkingLabel` remain true no-ops at
+   `rpc-mode.ts:178-192,209-215`, and `rpc-types.ts`'s `RpcExtensionUIRequest`
+   union, lines 213-248, still has no `"custom"` variant and `RpcCommand` has
+   no `extension_ui_input`-shaped keystroke command — pi-web's `custom()`
+   support is built entirely on its own `lib/types.ts` vocabulary, which is
+   richer than the shared `rpc-types.ts` contract.)
+   This is upstream in `pi-mono/packages/coding-agent`, not in Picot. **Picot
+   cannot receive `custom` frames from a real subprocess until this is
+   implemented in `rpc-mode.ts`** — pi-web only gets it because it bypasses
+   `rpc-mode.ts` entirely and calls `bindExtensions` with its own
+   `ExtensionUIContext` implementation in-process (§1). This is the single
+   biggest structural reason for the gap: **pi-web's "RPC mode" is a
+   same-process reimplementation of the UI context; Picot's RPC mode is the
+   literal upstream RPC mode, which is intentionally more limited today.**
+
+2. **`extension-ui-host.js` has no browser-side handler at all** for
+   `custom` — it's routed to the generic `default:` branch and answered
+   `{ cancelled: true, error: "unsupported" }` immediately (see
+   `extension-ui-host.js` and its own test:
+   `"reports TUI-only operations as unsupported"`). Even once upstream RPC
+   mode emits real `custom` frames, Picot's host JS would still need:
+   - a render loop that re-requests the component's rendered lines on
+     `requestRender()` (there's no such request today because there's no
+     emitter to trigger it — this would come for free once `rpc-mode.ts`
+     emits `method: "custom"` render frames the same way pi-web's
+     `emitCustomUiRender` does),
+   - an input path that turns DOM keydown/paste events into terminal escape
+     sequences and posts them back as `extension_ui_input` (pi-web's
+     `lib/terminal-input.ts` is directly portable — same escape-sequence
+     table works for any xterm-speaking backend),
+   - a modal/panel to host the ANSI-rendered lines (Picot's dialog/message
+     rendering already parses styled text elsewhere, so this is mostly
+     wiring, not new capability).
+
+## 5. `setStatus` / `setWidget` — smaller, purely browser-side gaps
+
+Unlike `custom()`, these **already work end-to-end at the protocol layer** in
+Picot today — `rpc-mode.ts` emits them from a real subprocess, the Rust
+bridge forwards them, and `extension-ui-host.js` already routes them to
+`hooks.status` / `hooks.widget`. The only thing missing is **generic
+rendering**:
+
+- `setStatus`: Picot's `hooks.status` throws away `statusKey` and always
+  displays a single hardcoded "Connected" string
+  (`status: (request) => setStatus(request.statusText || "Connected")`).
+  pi-web keeps a live `Map`/array keyed by `statusKey`
+  (`extensionStatuses`) and renders all of them via `ExtensionStatusBar`.
+  **Fix is purely frontend**: keep a `Map<statusKey, statusText>` (mirroring
+  `useAgentSession.ts`'s `setExtensionStatuses` reducer) and render it instead
+  of a single string.
+- `setWidget`: Picot's `hooks.widget` is a no-op except for one
+  extension-specific `widgetKey` check. pi-web keeps a
+  `Map<widgetKey, {lines, placement}>` (`extensionWidgets`) and renders all of
+  them above/below the composer via `ExtensionWidgets`. **Fix is purely
+  frontend**: generalize `rpiv-todo-mirror.js`'s special case into a generic
+  `Map<widgetKey, {lines, placement}>` renderer (e.g. a
+  `above-editor-widgets` / `below-editor-widgets` DOM container), falling back
+  to that generic renderer for any `widgetKey` that isn't already natively
+  mirrored (keep the `rpiv-todos` special case as an *override*, not the only
+  path).
+
+These two are low-risk, no-Rust-changes, no-upstream-changes fixes — pure
+browser JS, following the pattern pi-web already validated.
+
+## 6. Summary: what's actually blocking Picot today
+
+| Gap | Layer | Needs upstream (`pi-mono`) change? | Needs Rust (`src-tauri`) change? | Fix scope |
+|---|---|---|---|---|
+| Generic `setStatus` rendering (multiple keys) | `public/native/app.js` hook | No | No | Small, frontend-only |
+| Generic `setWidget` rendering (any extension, not just rpiv-todo) | `public/native/app.js` hook + a new widget container | No | No | Small, frontend-only |
+| `custom()` TUI components (e.g. interactive pickers/forms extensions build with `pi-tui`) | Needs `rpc-mode.ts` to actually emit `method: "custom"` render/input frames (it's currently a stub returning `undefined`) | **Yes** — `pi-mono/packages/coding-agent/src/modes/rpc/rpc-mode.ts` `custom()` | No (bridge already forwards arbitrary `extension_ui_*` frames) | Medium: needs upstream RPC support + a browser-side render/input loop modeled on pi-web's `ExtensionCustomPanel` + `terminal-input.ts` |
+| `setWorkingMessage`/`setWorkingIndicator`/`setFooter`/`setHeader`/custom editor components | Not emitted by RPC mode for *either* host (both are no-ops in `rpc-mode.ts`) | Yes, if ever wanted | No | Out of scope — neither pi-web nor Picot supports these; not a Picot-specific regression |
+
+**Bottom line for the user's premise:** it's *not* that "extensions don't
+report state to Picot's RPC" — the RPC layer (subprocess → Rust bridge →
+WebSocket) already carries `setStatus`/`setWidget`/`custom` frames correctly
+for anything the upstream `pi` binary emits. The real gaps are:
+
+1. Picot's **browser JS** (`extension-ui-host.js` / `app.js`) only special-cases
+   one extension's widget and discards everyone else's `setStatus`/`setWidget`
+   payloads — that's fixable entirely inside Picot, no upstream dependency.
+2. `custom()` (arbitrary interactive extension UI) is unimplemented **in the
+   real `pi --mode rpc` binary itself** (`rpc-mode.ts`), so no client of the
+   real binary — including a hypothetical from-scratch Picot rewrite — can
+   receive those frames yet. pi-web only appears to support it because it
+   doesn't go through that binary at all; it embeds the SDK and hand-rolls its
+   own `ExtensionUIContext`, which is a fundamentally different integration
+   strategy than Picot's "spawn the real CLI in RPC mode" approach.
+
+## 7. Suggested path for Picot
+
+1. **Ship the low-risk wins first** (§5): generalize `setStatus` and
+   `setWidget` handling in `public/native/app.js` /
+   `extension-ui-host.js` to key by `statusKey`/`widgetKey` and render N
+   items, not 1. This alone recovers a meaningful slice of "extension
+   functionality invisible in Picot" with zero upstream/Rust changes.
+2. **File the `custom()` RPC gap upstream** against
+   `pi-mono/packages/coding-agent/src/modes/rpc/rpc-mode.ts` — propose an
+   `extension_ui_request { method: "custom", lines }` /
+   `extension_ui_input { id, data }` protocol identical to pi-web's
+   `custom-ui-terminal.ts` approach, since pi-web already proves the design
+   works and the RPC type definitions (`rpc-types.ts`) can be extended to
+   match `lib/types.ts`'s `ExtensionUiRequest` union (which already has the
+   `method: "custom"` / `closed` shape pi-web invented — reusing it keeps the
+   two hosts' protocols convergent instead of diverging further).
+3. **Once upstream emits `custom` frames**, port pi-web's
+   `lib/terminal-input.ts` (escape-sequence mapping) and the
+   render/modal pattern from `ExtensionCustomPanel` into Picot's JS — the
+   logic is host-agnostic (DOM keydown → ANSI bytes, ANSI-styled
+   `string[]` → styled DOM) and doesn't depend on pi-web's in-process
+   embedding.
+
+## 8. Concrete design notes (added after re-verifying against current code)
+
+### Phase 1 — generic `setStatus`/`setWidget` (frontend-only, no upstream/Rust dependency)
+
+Copy pi-web's keyed-state model as-is. Note pi-web itself uses a plain array
+with filter-then-append dedup keyed by `statusKey`/`widgetKey`
+(`hooks/useAgentSession.ts:791-810`), not an actual `Map` — replicate that
+exact shape rather than inventing a new one, since it's already
+battle-tested:
+
+- `app.js`'s `hooks.status`/`hooks.widget` become
+  `statusItems: {key, text}[]` / `widgetItems: {key, lines, placement}[]`,
+  deduped by `key`, removing an entry when `statusText === undefined`.
+- Add generic `above-editor-widgets` / `below-editor-widgets` DOM containers
+  and a status bar that iterate over *all* keys, not just `rpiv-todos`.
+- Keep `rpiv-todo-mirror.js` as an **override**, not the only path: if a
+  native mirror exists for a `widgetKey`, prefer it; otherwise fall back to
+  the generic renderer.
+
+Low risk, immediately visible payoff, no dependency on phases 2/3.
+
+### Phase 2 — upstream protocol extension (`pi-mono`: `rpc-mode.ts` + `rpc-types.ts`)
+
+This is the actual blocker, and benefits both hosts:
+
+1. Add a `custom` variant to `rpc-types.ts`'s `RpcExtensionUIRequest` union,
+   shaped exactly like pi-web's own `ExtensionUiRequest`
+   (`{method: "custom", id, lines: string[], closed?: boolean}`) — reusing
+   pi-web's already-proven shape keeps the two hosts' protocols convergent.
+2. Add `extension_ui_input {id, data: string}` to `RpcCommand` as the
+   keystroke-return channel (distinct from the one-shot
+   `extension_ui_response` used for select/confirm).
+3. Implement `rpc-mode.ts`'s `custom()` following pi-web's
+   `requestExtensionCustomUi` design: build a headless `TUI`
+   (`{terminal: {columns, rows, kittyProtocolActive: false}, requestRender()}`),
+   call the extension's factory to get a `Component`, emit
+   `render(width): string[]` results as `extension_ui_request{method:"custom",lines}`,
+   call `component.handleInput(data)` on incoming `extension_ui_input` and
+   re-render, and emit `{lines: [], closed: true}` on `done()`/dispose. This
+   logic is host-agnostic — pi-web already validated the design; it just
+   needs to be re-targeted at stdout JSONL frames instead of an in-process
+   event emitter.
+
+### Phase 3 — Picot browser-side render/input loop
+
+Once upstream actually emits `custom` frames, three pieces, all "same logic,
+different host":
+
+1. **Keystroke encoding**: `lib/terminal-input.ts`'s `toTerminalKeyData()` /
+   `asBracketedPaste()` are pure functions with no React/pi-web-specific
+   state — portable byte-for-byte. The mapping table (arrows, Home/End,
+   Ctrl-combos via `code & 0x1f`, Alt-prefix via `\x1b`+char, Enter/Tab's
+   Shift variants) is standard terminal escape-sequence trivia, host-agnostic.
+2. **ANSI rendering**: `lib/ansi.ts`'s `parseAnsiLine()` (SGR-only —
+   8-color/bright/256-color/truecolor) plus `normalizeCustomPanelLines()`
+   (strips TUI box-drawing borders and cursor markers) can be ported wholesale
+   or mapped onto Picot's existing ANSI-rendering infra (dialogs, tool cards).
+3. **Input capture + queue integration** — this is where Picot's extra
+   complexity vs. pi-web actually lives, and needs deliberate design: pi-web
+   is a single-session web page, so `ExtensionCustomPanel` just mounts a
+   hidden `<textarea>` and captures keydown/composition/paste directly. Picot
+   already has a per-session foreground/background queue for blocking dialogs
+   (`extension-ui-host.js`'s `#queues`/`#inFlight`, `flushForegroundQueue()`)
+   — `custom` UI panels must plug into the *same* mechanism: only the
+   foreground session's `custom` panel should mount keyboard capture and
+   drive a `requestRender()` loop; background sessions' `custom` frames
+   should just cache the latest `lines` and defer mounting the render/input
+   loop until that session becomes foreground. Otherwise multiple sessions'
+   custom panels would fight over keyboard focus or render in the
+   background for no reason.
+
+### A sizing detail worth flagging
+
+pi-web's headless terminal size is fixed per-request (default 92×40, clamped
+40-140 via `options.overlayOptions().width`) — it doesn't adapt to the
+browser window. Picot can start by copying this simple fixed/clamped-width
+model; making the panel width follow real DOM dimensions (passing the
+panel's actual available column count into the `custom` request) is a
+nice-to-have for later, not a blocker for a first version.
+
+**Priority**: Phase 1 can ship today, independently, zero risk. Phase 2 must
+land in `pi-mono` first (the protocol design can be copied from pi-web's
+already-working implementation, no fresh design needed). Phase 3 is mostly
+mechanical porting — the only genuinely new design work is integrating with
+Picot's existing foreground/background session queue.

--- a/docs/extension-ui-parity-pi-web-vs-picot.zh-CN.md
+++ b/docs/extension-ui-parity-pi-web-vs-picot.zh-CN.md
@@ -1,0 +1,321 @@
+# Extension Command / Custom UI 对等性分析：pi-web vs Picot
+
+对比两个 Web 端 host 如何对接同一套协议（`pi --mode rpc`，定义在
+`pi-mono/packages/coding-agent/src/modes/rpc/`），以及为什么 Picot 目前会
+丢失一整类 pi-web 支持的 extension 功能。
+
+## 1. 两端如何接入 RPC 协议
+
+| | **pi-web** | **Picot** |
+|---|---|---|
+| 运行方式 | 通过 SDK 将 `@earendil-works/pi-coding-agent` **内嵌在同一进程**中（`createAgentSessionFromServices`、`lib/rpc-manager.ts` 中的 `AgentSessionWrapper`） | 把真实的 `pi` 二进制作为**子进程**启动，带 `--mode rpc`（`src-tauri/src/native_pi_manager.rs:44` 的 `--mode rpc`），通过 stdin/stdout JSONL 通信（`pi_rpc_bridge.rs`） |
+| Extension 绑定方式 | 直接调用 `session.bindExtensions({ uiContext, mode: "rpc", commandContextActions, ... })`，`uiContext` 是一个 **JS 对象**实现——无需任何序列化 | Extension 运行在子进程 `pi` 内部，与*它自己的* RPC 层（`rpc-mode.ts`）通信，后者会把 `ExtensionUIContext` 的调用序列化为 stdout 上的 `extension_ui_request` JSON 帧 |
+| 到浏览器的传输 | 同进程内的事件发射器（`AgentEvent`）→ SSE/WebSocket → React 客户端 | 子进程的 JSON 帧 → Rust `PiRpcBridge` → 原样转发到 Tauri WebSocket/host origin → 前端 JS |
+
+两端最终暴露的是**同一套协议**（`extension_ui_request` / `extension_ui_response`、
+`get_commands` 等，定义在 `rpc-types.ts`）。区别不在协议本身，而在于每个
+前端**实际实现了协议的多少**。
+
+## 2. Command 执行（`get_commands`、slash command）
+
+两端都会调用 `{ type: "get_commands" }`，拿到
+`{ commands: RpcSlashCommand[] }`（extension 注册的命令 + prompt 模板 + skill），
+并据此构建 slash 命令面板：
+
+- pi-web：`components/ChatInput.tsx`（`buildSlashCommandLayout`，按来源分组：
+  builtin/extension/prompt/skill）。
+- Picot：`public/native/composer/slash-commands.js`（`buildCommandCatalog`）+
+  `public/native/composer/composer-slash-menu.js`，数据来自
+  `app.js:640-645`（`loadCommands()` → `runtime.request({ type: "get_commands" }, target)`；
+  调用点已从旧版的 `app.js:611` 挪过来，行为不变）。
+
+**这部分两端是对等的。** 执行一个命令在两边都只是发送一个 `prompt`/`steer`
+RPC 命令；命令的*副作用*（工具调用、消息历史）在任何地方都能正常渲染，
+因为它们走的是正常的消息流，而不是 `ExtensionUIContext`。
+
+真正的差距完全出现在**命令/extension 运行期间**，当它想要渲染或读取一些
+超出常规聊天记录范围的东西时。
+
+## 3. Extension UI 方法——实现情况对照表
+
+`ExtensionUIContext`（`pi-mono/.../core/extensions/types.ts:124`）大约有 20
+个方法。每一个都会变成带 `method` 字段的 `extension_ui_request` 帧。以下是
+每个前端对每个方法的处理情况：
+
+| 方法 | RPC 帧类型 | pi-web（`lib/rpc-manager.ts`、`hooks/useAgentSession.ts`、`components/ChatWindow.tsx`） | Picot（`extension-ui-host.js`、`app.js`、`dialog.js`） |
+|---|---|---|---|
+| `select` / `confirm` / `input` / `editor` | 阻塞式，需要 `extension_ui_response` | ✅ 渲染为一个模态框（`ExtensionDialog`，用 React 构建） | ✅ 渲染为模态框（`showNativeDialog`）或内联卡片（`showInlineExtensionPrompt`），按 session 排队 |
+| `notify` | 发后不理 | ✅ `addNotice` → toast/系统消息 | ✅ `messageRenderer.renderSystemMessage` |
+| `setStatus` | 发后不理 | ✅ `ExtensionStatusBar` 渲染 `{key,text}` 的 pill 标签 | ✅ 只显示成一个通用的 "Connected" 文本（`setStatus(request.statusText || "Connected")`）——status 的 **key** 被丢弃了，导致多个并发的状态全部塌缩成一个字符串 |
+| `setWidget`（仅 string[] 内容） | 发后不理 | ✅ `ExtensionWidgets` 把 `lines[]` 渲染在编辑器上方/下方，按 `widgetKey` 建索引，维护一个活跃的 `Map<key, widget>` | ⚠️ **只对一个 extension 特殊处理**（`rpiv-todo-mirror.js` 只匹配 `widgetKey === "rpiv-todos"`）；其他所有 extension 的 widget 都命中同一个 hook 后被静默丢弃（`widget: (request) => { if (isRpivTodoWidgetRequest(request)) return; }`——没有 `else` 分支） |
+| `setWidget`（组件工厂函数写法） | **在 RPC 层面根本无法表达** | 不支持（RPC 模式会去掉工厂函数，见 `rpc-mode.ts` 中的注释：*"Only support string arrays in RPC mode — factory functions are ignored"*） | 同样的限制——这是协议层面的缺口，与具体 host 无关 |
+| `setTitle` | 发后不理 | ✅ 设置 `document.title` | ✅ 设置 `document.title` |
+| `set_editor_text` / `pasteToEditor` | 发后不理 | ✅ 通过 `chatInputRef` 插入到输入框 | ✅ 直接设置 `input.value` |
+| `custom(factory, …)`（任意交互式 TUI 组件） | 需要 `extension_ui_request(method:"custom")` 渲染帧 + `extension_ui_input` 键盘输入帧 + 关闭时的 `extension_ui_response` | ✅ **完整支持**——见第 4 节 | ❌ **明确拒绝**：`extension-ui-host.js` 里没有 `case "custom"`，会落入 `default:` 分支，立即回复 `{ cancelled: true, error: "unsupported" }` |
+| `setWorkingMessage` / `setWorkingVisible` / `setWorkingIndicator` / `setHiddenThinkingLabel` | RPC 模式压根不会发出这些（`rpc-mode.ts` 中都是空实现，注释写着：*"not supported in RPC mode - requires TUI loader access"*） | 不适用（永远不会发出） | 不适用（永远不会发出） |
+| `setFooter` / `setHeader` | RPC 模式压根不会发出（空实现） | 不适用 | 不适用 |
+| `getEditorText` | 同步方法，无法在 RPC 上做往返 | 永远返回 `""` | 客户端也没有实现 |
+| `addAutocompleteProvider` / `setEditorComponent` | RPC 不支持 | 空操作 | 未暴露 |
+| 主题相关方法（`getAllThemes`、`setTheme` 等） | RPC 返回空结果/失败 | 打了桩 | 未暴露 |
+
+**核心发现：** `setStatus`/`setWidget` 帧确实被 Picot 的 bridge 收到了，
+但前端除了一个 hardcode 的 extension 之外，把这些负载全部丢弃了；而
+`custom` 在 JS 层被直接拒绝——即便 Rust bridge（`pi_rpc_bridge.rs`）和
+运行时帧分类逻辑（`BridgeFrame::ExtensionUi`）早已正确转发了这些帧。
+**这个缺口 100% 出在浏览器端 JS（`extension-ui-host.js`），不在 Rust，
+不在 RPC 协议本身，也不在 `pi` 二进制里。**
+
+> **2026-08-02 复核**：以上结论对照当前代码全部成立。文件位置有变动：
+> `extension-ui-host.js` 现在在 `public/native/extensions/extension-ui-host.js`，
+> `rpiv-todo-mirror.js` 在 `public/native/features/rpiv-todo-mirror.js`。
+> dispatch switch（`extension-ui-host.js:143-169`）依然没有 `case "custom"`，
+> 也没有 `pasteToEditor` 分支——两者都落到 `default:`，回复
+> `{ cancelled: true, error: "unsupported" }`。`app.js:265-299` 里的
+> `hooks.status`/`hooks.widget` 也没变：`status` 丢弃 `statusKey`
+> （`setStatus(request.statusText || "Connected")`，第 284 行），`widget`
+> 除了 `rpiv-todos` 特判外没有 `else` 分支（第 293-297 行）。
+> `pi_rpc_bridge.rs` 的 `read_frames()`（第 279-319 行）依然只按 `type`
+> 字段前缀（`extension_ui*`）分类成 `BridgeFrame::ExtensionUi`，从不检查
+> `method`——再次确认瓶颈不在 bridge。
+
+## 4. 为什么 pi-web 能做到 `custom()`，Picot 做不到
+
+`ExtensionUIContext.custom()` 允许 extension 挂载一个用 `pi-tui` 原语
+（`Component`、`TUI`、`Theme`、`KeybindingsManager`）构建的任意交互式组件，
+并获得原始按键输入，直到它调用 `done()`。
+
+### pi-web 的做法：同一进程内的 headless TUI 模拟层
+
+因为 pi-web 是把 SDK 内嵌在同一进程中，它根本不需要为 `custom()` 做 RPC
+序列化——可以直接用一个**headless 的 `TUI` 实现**去调用 extension 的
+factory 函数：
+
+- `lib/custom-ui-terminal.ts` —— `createHeadlessCustomUiTui()` 返回一个假的
+  `{ terminal: { columns, rows, kittyProtocolActive: false }, requestRender() }`，
+  这个对象足以满足 `TUI` 接口，让 `pi-tui` 的 `Component` 把自己渲染成一个
+  带 ANSI 样式的字符串数组。
+- `lib/rpc-manager.ts`（`requestExtensionCustomUi`）会调用
+  `factory(tui, PLAIN_TEXT_THEME, CUSTOM_UI_KEYBINDINGS, done)`，拿到一个
+  带有 `.render(width): string[]` 方法的 `Component`，每次 `requestRender()`
+  触发时重新调用 `.render()`，并把渲染出的行以
+  `extension_ui_request { method: "custom", lines }` 的形式发出。
+- 因为 pi-web *本身就是* RPC 端点（它是 SDK 本体，不是某个 RPC 服务的客户端），
+  整个流程**完全不需要离开这个模块**——没有子进程，组件对象本身也不需要
+  额外的 IPC 帧，只有渲染出的文本行会跨越到浏览器。
+- 按键会以 `extension_ui_input { id, data }` 的形式回传（见
+  `lib/rpc-manager.ts:610`，由 `hooks/useAgentSession.ts:753` 触发），
+  传给 `component.handleInput(data)`——这正是一个真实终端会喂给 `pi-tui`
+  组件的东西（原始 ANSI/键盘转义序列，由浏览器端的 `lib/terminal-input.ts`
+  产生——`toTerminalKeyData()` / `asBracketedPaste()`）。
+- 浏览器端是 `components/ChatWindow.tsx` 里的 `ExtensionCustomPanel`：一个
+  带隐藏 `<textarea>` 的模态框，捕获 keydown/组合输入/粘贴事件，转换成终端
+  转义序列，还有一个 `<pre>` 用 `parseAnsiLine()`（`lib/ansi.ts`）渲染带
+  ANSI 样式的行。
+
+所以 pi-web 实际上重新实现了"一个渲染成 HTML 的终端字符网格，由真实按键
+驱动"——一个为 `pi-tui` 组件量身定制的、极简的类 xterm 桥接层。它不需要
+`pi-tui` 真正的终端渲染器，只需要 `Component.render(width): string[]` +
+`Component.handleInput(data)`，这正是 `pi-tui` 组件对外公开的完整接口契约。
+
+### Picot 要做到同样的事情，缺了什么
+
+Picot 的架构其实已经具备做这件事的正确形态——可以说它比 pi-web 的处境
+*更好*，因为：
+
+1. Rust bridge 已经把 `method: "custom"` 的帧分类为 `BridgeFrame::ExtensionUi`
+   并转发出去了——这部分不需要改动。
+2. `pi_rpc_bridge.rs` 的 `request()`/`send_frame()` 已经能双向传输任意 JSON，
+   所以 `extension_ui_input`（按键）帧只是 bridge 无需关心内容的又一种 JSON
+   负载而已。
+3. Picot 已经为其他功能（对话框、工具卡片）建好了 ANSI 感知的渲染基础设施，
+   这些可以直接复用/扩展。
+
+但确实缺了两个关键部分：
+
+1. **RPC 子进程本身根本不会发出 `method: "custom"` 帧**，因为 `rpc-mode.ts`
+   里的 `custom()` 实现是一个硬编码的桩函数：
+   ```ts
+   async custom() {
+     // Custom UI not supported in RPC mode
+     return undefined as never;
+   }
+   ```
+   （截至 2026-08-02 复核，`rpc-mode.ts:227-230` 代码原封不动；同时确认
+   `setFooter`/`setHeader`/`setWorkingMessage`/`setWorkingVisible`/
+   `setWorkingIndicator`/`setHiddenThinkingLabel` 在 `rpc-mode.ts:178-192,209-215`
+   仍是纯空操作，`rpc-types.ts` 里的 `RpcExtensionUIRequest` 联合类型
+   （第 213-248 行）依然没有 `"custom"` 变体，`RpcCommand` 也没有
+   `extension_ui_input` 形状的按键回传命令——pi-web 对 `custom()` 的支持
+   完全建立在它自己的 `lib/types.ts` 词汇表上，比共享的 `rpc-types.ts`
+   协议更丰富。）
+   这是在上游 `pi-mono/packages/coding-agent` 里，不在 Picot 里。**Picot
+   在这个功能被 `rpc-mode.ts` 实现之前，永远不可能从一个真实子进程收到
+   `custom` 帧**——pi-web 能拿到只是因为它完全绕开了 `rpc-mode.ts`，
+   在进程内自己实现了一套 `ExtensionUIContext`（见第 1 节）。这是造成
+   这个差距的最根本的结构性原因：**pi-web 的"RPC 模式"是同进程内对 UI
+   context 的重新实现；Picot 的 RPC 模式是字面意义上的上游 RPC 模式，
+   而这个模式目前功能上就是更受限的。**
+
+2. **`extension-ui-host.js` 里根本没有针对 `custom` 的浏览器端处理逻辑**——
+   它被路由到通用的 `default:` 分支，立即回复
+   `{ cancelled: true, error: "unsupported" }`（见 `extension-ui-host.js`
+   及其自带的测试："reports TUI-only operations as unsupported"）。
+   即便上游未来真的开始发出 `custom` 帧，Picot 的 host JS 仍然需要：
+   - 一个渲染循环，在 `requestRender()` 时重新请求组件渲染出的文本行
+     （目前没有这样的触发机制，因为根本没有发射器会触发它——一旦
+     `rpc-mode.ts` 像 pi-web 的 `emitCustomUiRender` 那样发出 `method: "custom"`
+     渲染帧，这部分就能顺理成章地补上），
+   - 一个输入通路，把 DOM 的 keydown/粘贴事件转换成终端转义序列，再以
+     `extension_ui_input` 的形式发回去（pi-web 的 `lib/terminal-input.ts`
+     可以直接拿来用——同一套转义序列表适用于任何"说 xterm 语言"的后端），
+   - 一个用来承载 ANSI 渲染文本行的模态框/面板（Picot 在别处已经解析过
+     带样式的文本，所以这大部分是接线工作，不是全新的能力）。
+
+## 5. `setStatus` / `setWidget`——更小的、纯浏览器端的差距
+
+与 `custom()` 不同，这两个方法**在 Picot 今天的实现里已经端到端可以工作**
+——`rpc-mode.ts` 会从真实子进程发出它们，Rust bridge 会转发它们，
+`extension-ui-host.js` 也已经把它们路由到了 `hooks.status` / `hooks.widget`。
+唯一缺的是**通用渲染逻辑**：
+
+- `setStatus`：Picot 的 `hooks.status` 丢弃了 `statusKey`，始终只显示一个
+  硬编码的 "Connected" 字符串
+  （`status: (request) => setStatus(request.statusText || "Connected")`）。
+  pi-web 维护一个按 `statusKey` 索引的活跃 `Map`/数组
+  （`extensionStatuses`），并通过 `ExtensionStatusBar` 把它们全部渲染出来。
+  **修复纯粹在前端**：维护一个 `Map<statusKey, statusText>`
+  （对照 `useAgentSession.ts` 里的 `setExtensionStatuses` reducer），
+  渲染这个 map 而不是单个字符串。
+- `setWidget`：Picot 的 `hooks.widget` 除了一个针对特定 extension 的
+  `widgetKey` 判断之外什么都不做。pi-web 维护一个
+  `Map<widgetKey, {lines, placement}>`（`extensionWidgets`），通过
+  `ExtensionWidgets` 把它们全部渲染在输入框上方/下方。**修复纯粹在前端**：
+  把 `rpiv-todo-mirror.js` 里的特殊逻辑泛化成一个通用的
+  `Map<widgetKey, {lines, placement}>` 渲染器（例如新增一个
+  `above-editor-widgets` / `below-editor-widgets` 的 DOM 容器），对于
+  任何还没有原生镜像实现的 `widgetKey`，都回退到这个通用渲染器（保留
+  `rpiv-todos` 的特殊处理作为一种*覆盖*，而不是唯一的路径）。
+
+这两处都是低风险、不涉及 Rust 改动、不依赖上游改动的修复——纯浏览器
+JS 改动，遵循 pi-web 已经验证过的模式即可。
+
+## 6. 总结：Picot 目前真正被卡住的地方
+
+| 差距 | 所在层级 | 需要上游（`pi-mono`）改动？ | 需要 Rust（`src-tauri`）改动？ | 修复范围 |
+|---|---|---|---|---|
+| `setStatus` 的通用渲染（支持多个 key） | `public/native/app.js` 的 hook | 否 | 否 | 小，纯前端 |
+| `setWidget` 的通用渲染（支持任意 extension，不只是 rpiv-todo） | `public/native/app.js` 的 hook + 新的 widget 容器 | 否 | 否 | 小，纯前端 |
+| `custom()` TUI 组件（例如 extension 用 `pi-tui` 构建的交互式选择器/表单） | 需要 `rpc-mode.ts` 真正发出 `method: "custom"` 的渲染/输入帧（目前是个返回 `undefined` 的桩函数） | **是** —— `pi-mono/packages/coding-agent/src/modes/rpc/rpc-mode.ts` 的 `custom()` | 否（bridge 已经能转发任意 `extension_ui_*` 帧） | 中：需要上游 RPC 支持 + 一套仿照 pi-web 的 `ExtensionCustomPanel` + `terminal-input.ts` 的浏览器端渲染/输入循环 |
+| `setWorkingMessage`/`setWorkingIndicator`/`setFooter`/`setHeader`/自定义编辑器组件 | RPC 模式对**两端**都不会发出这些（`rpc-mode.ts` 里都是空操作） | 如果以后想要的话，是 | 否 | 超出范围——pi-web 和 Picot 都不支持这些；不是 Picot 特有的回退 |
+
+**回到用户最初的假设：** 问题**不是**"extension 没有把状态汇报给 Picot 的
+RPC"——RPC 层（子进程 → Rust bridge → WebSocket）本身已经在正确地承载
+`setStatus`/`setWidget`/`custom` 这些帧，只要上游 `pi` 二进制发出它们就行。
+真正的缺口是：
+
+1. Picot 的**浏览器 JS**（`extension-ui-host.js` / `app.js`）只对一个
+   extension 的 widget 做了特殊处理，其他所有 extension 的
+   `setStatus`/`setWidget` 负载都被丢弃——这一点完全可以在 Picot 内部修复，
+   不依赖上游。
+2. `custom()`（任意交互式 extension UI）**在真实的 `pi --mode rpc` 二进制
+   本身里就没有实现**（`rpc-mode.ts`），所以任何使用这个真实二进制的客户端
+   ——包括一个假想中从零重写的 Picot——目前都不可能收到这些帧。pi-web
+   看起来"支持"这个功能，只是因为它压根没有走这个二进制，而是把 SDK
+   内嵌进来，自己手写了一套 `ExtensionUIContext`——这和 Picot"启动真实
+   CLI 的 RPC 模式"的集成策略,是根本不同的两条路线。
+
+## 7. Picot 的建议路径
+
+1. **先做低风险的收益**（第 5 节）：把 `public/native/app.js` /
+   `extension-ui-host.js` 里的 `setStatus` 和 `setWidget` 处理泛化成按
+   `statusKey`/`widgetKey` 建索引、能渲染 N 项而不是 1 项。仅这一项就能
+   在零上游/零 Rust 改动的前提下，收回"extension 功能在 Picot 里不可见"
+   这个问题里相当一部分的份额。
+2. **向上游提出 `custom()` 的 RPC 缺口**，针对
+   `pi-mono/packages/coding-agent/src/modes/rpc/rpc-mode.ts`——提议一套
+   与 pi-web 的 `custom-ui-terminal.ts` 方案一致的协议：
+   `extension_ui_request { method: "custom", lines }` /
+   `extension_ui_input { id, data }`，因为 pi-web 已经证明了这个设计可行，
+   而且 RPC 的类型定义（`rpc-types.ts`）可以扩展成与 `lib/types.ts` 里
+   `ExtensionUiRequest` 联合类型一致的形态（它已经有了 pi-web 发明的
+   `method: "custom"` / `closed` 结构——复用它能让两个 host 的协议保持
+   收敛，而不是继续分裂）。
+3. **一旦上游开始发出 `custom` 帧**，把 pi-web 的 `lib/terminal-input.ts`
+   （转义序列映射表）以及 `ExtensionCustomPanel` 的渲染/模态框模式移植到
+   Picot 的 JS 里——这套逻辑与 host 无关（DOM keydown → ANSI 字节，
+   带 ANSI 样式的 `string[]` → 带样式的 DOM），并不依赖 pi-web 那种
+   同进程内嵌的架构。
+
+## 8. 具体设计方案（对照当前代码复核后新增）
+
+### 阶段一 —— `setStatus`/`setWidget` 通用化（纯前端，不依赖上游/Rust）
+
+直接照抄 pi-web 的 keyed 状态模型。注意 pi-web 自己用的其实是"数组 +
+按 `statusKey`/`widgetKey` filter-then-append 去重"（`hooks/useAgentSession.ts:791-810`），
+并不是真正的 `Map`——照搬这个已经跑通的形状，别自己发明新结构：
+
+- `app.js` 的 `hooks.status`/`hooks.widget` 改成维护
+  `statusItems: {key, text}[]` / `widgetItems: {key, lines, placement}[]`，
+  按 `key` 去重，`statusText === undefined` 时移除该条目。
+- 新增通用的 `above-editor-widgets` / `below-editor-widgets` DOM 容器和状态栏，
+  遍历渲染*所有* key，而不是只认 `rpiv-todos`。
+- 保留 `rpiv-todo-mirror.js` 作为**覆盖（override）**而非唯一路径：某个
+  `widgetKey` 如果有原生镜像组件就优先用它，否则回退到通用渲染器。
+
+风险低、收益立即可见，不依赖阶段二/三。
+
+### 阶段二 —— upstream 协议扩展（`pi-mono`：`rpc-mode.ts` + `rpc-types.ts`）
+
+这才是真正的阻塞点，两个 host 都受益：
+
+1. 给 `rpc-types.ts` 的 `RpcExtensionUIRequest` 联合类型加一个 `custom` 变体，
+   形状照抄 pi-web 自己的 `ExtensionUiRequest`
+   （`{method: "custom", id, lines: string[], closed?: boolean}`）——复用
+   pi-web 已验证过的形状能让两个 host 的协议保持收敛。
+2. 给 `RpcCommand` 加 `extension_ui_input {id, data: string}`，作为按键回传
+   通道（区别于 select/confirm 用的一次性 `extension_ui_response`）。
+3. 按 pi-web `requestExtensionCustomUi` 的设计实现 `rpc-mode.ts` 的
+   `custom()`：造一个 headless `TUI`
+   （`{terminal: {columns, rows, kittyProtocolActive: false}, requestRender()}`），
+   调用 extension 的 factory 拿到 `Component`，把
+   `render(width): string[]` 的结果发成
+   `extension_ui_request{method:"custom",lines}`；收到 `extension_ui_input`
+   时调 `component.handleInput(data)` 再重渲染；`done()`/dispose 时发出
+   `{lines: [], closed: true}`。这套逻辑与 host 无关——pi-web 已经验证过
+   设计可行，只需要把目标从进程内事件发射器换成 stdout JSONL 帧。
+
+### 阶段三 —— Picot 浏览器端渲染/输入循环
+
+一旦上游真的发出 `custom` 帧，需要三块，都是"同款逻辑，换宿主"：
+
+1. **按键编码**：`lib/terminal-input.ts` 的 `toTerminalKeyData()` /
+   `asBracketedPaste()` 是纯函数，不依赖任何 React/pi-web 特有状态——可以
+   逐字节移植。映射表（方向键、Home/End、Ctrl 组合走 `code & 0x1f`、Alt
+   前缀走 `\x1b`+字符、Enter/Tab 的 Shift 变体）是标准终端转义序列知识，
+   与 host 无关。
+2. **ANSI 渲染**：`lib/ansi.ts` 的 `parseAnsiLine()`（仅处理 SGR——8色/
+   亮色/256色/truecolor）加上 `normalizeCustomPanelLines()`（剥掉 TUI 的
+   box-drawing 边框和光标标记）可以整体移植，或者接到 Picot 已有的 ANSI
+   渲染基建（对话框、工具卡片）上。
+3. **输入捕获 + 队列整合**——这是 Picot 相比 pi-web 多出来的复杂度，
+   需要认真设计：pi-web 是单会话网页，`ExtensionCustomPanel` 直接挂一个
+   隐藏 `<textarea>` 捕获 keydown/组合输入/粘贴。Picot 已经有一套针对
+   阻塞式对话框的前台/后台会话队列（`extension-ui-host.js` 的
+   `#queues`/`#inFlight`、`flushForegroundQueue()`）——`custom` UI 面板
+   必须接入**同一套**机制：只有前台会话的 `custom` 面板才应该挂载键盘
+   捕获、驱动 `requestRender()` 循环；后台会话的 `custom` 帧应该只缓存
+   最新的 `lines`，等该会话切到前台时才挂载渲染/输入循环。否则多个会话
+   的 custom 面板会互相抢键盘焦点，或者在后台空转渲染。
+
+### 一个值得留意的尺寸细节
+
+pi-web 的 headless 终端尺寸是按请求固定的（默认 92×40，通过
+`options.overlayOptions().width` 限幅 40-140）——不会随浏览器窗口自适应。
+Picot 可以先照抄这个简单的固定/限幅宽度模型；让面板宽度跟随真实 DOM
+尺寸（把面板实际可用列数传进 `custom` 请求）是后续的锦上添花，不是
+第一版的阻塞项。
+
+**优先级**：阶段一今天就能独立上线，零风险。阶段二必须先在 `pi-mono`
+落地（协议设计可以直接照抄 pi-web 已经跑通的实现，不需要重新设计）。
+阶段三基本是机械式移植——唯一真正需要新设计的是和 Picot 已有的前台/
+后台会话队列做整合。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picot",
-  "version": "0.4.3-10001",
+  "version": "0.4.3-10002",
   "description": "Local Codex-style desktop GUI for the Pi coding agent",
   "keywords": [
     "picot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picot",
-  "version": "0.4.2",
+  "version": "0.4.3-10001",
   "description": "Local Codex-style desktop GUI for the Pi coding agent",
   "keywords": [
     "picot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picot",
-  "version": "0.4.3-10002",
+  "version": "0.4.3-10003",
   "description": "Local Codex-style desktop GUI for the Pi coding agent",
   "keywords": [
     "picot",

--- a/public/native/app.js
+++ b/public/native/app.js
@@ -1737,11 +1737,16 @@ async function handleRuntimeEvent(event) {
       break;
     case "message_update":
       if (!streamingElement) {
+        // message_update is delta-only: it carries no cumulative `message`
+        // field, only usage + assistantMessageEvent deltas. Create an empty
+        // placeholder so we never pass undefined into renderAssistantMessage.
         showLiveProcessIndicator();
-        streamingElement = messageRenderer.renderAssistantMessage(event.message, true);
-      } else {
-        messageRenderer.updateStreamingMessage(streamingElement, event.message?.content ?? []);
+        streamingElement = messageRenderer.renderAssistantMessage(
+          { role: "assistant", content: [] },
+          true,
+        );
       }
+      messageRenderer.updateStreamingMessage(streamingElement, event.message?.content ?? []);
       break;
     case "message_end":
       if (event.message?.role === "assistant" && streamingElement) {

--- a/public/native/settings/skills-page.css
+++ b/public/native/settings/skills-page.css
@@ -193,6 +193,20 @@
   cursor: not-allowed;
 }
 
+.skills-group-enable-all {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex: 0 0 auto;
+  padding-left: var(--space-2);
+}
+
+.skills-enable-all-label {
+  color: var(--text-dim);
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+}
+
 .skills-skill-description {
   line-height: 1.45;
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,6 +81,24 @@ case "$ARCH" in
   *)                die "Unsupported architecture: $ARCH" ;;
 esac
 
+# ── Detect Linux package manager ──────────────────────────────────────────────
+PKG_MGR=""
+if [ "$PLATFORM" = "linux" ]; then
+  if command -v apt-get &>/dev/null; then
+    PKG_MGR="apt"
+  elif command -v dpkg &>/dev/null; then
+    PKG_MGR="dpkg"
+  elif command -v dnf &>/dev/null; then
+    PKG_MGR="dnf"
+  elif command -v yum &>/dev/null; then
+    PKG_MGR="yum"
+  elif command -v rpm &>/dev/null; then
+    PKG_MGR="rpm"
+  else
+    die "No supported package manager found (apt/dpkg/dnf/yum/rpm)."
+  fi
+fi
+
 # ── Resolve version ───────────────────────────────────────────────────────────
 header "🎯  ${APP_NAME} Installer"
 if is_snap_path "$(command -v curl)"; then
@@ -112,15 +130,22 @@ case "$PLATFORM" in
     esac
     ;;
   linux)
-    case "$ARCH_NORM" in
-      x86_64) FILENAME="${APP_NAME}_${VER}_amd64.AppImage"   ;;
-      arm64)  FILENAME="${APP_NAME}_${VER}_aarch64.AppImage" ;;
+    case "$PKG_MGR" in
+      apt|dpkg)
+        case "$ARCH_NORM" in
+          x86_64) FILENAME="${APP_NAME}_${VER}_amd64.deb"  ;;
+          arm64)  FILENAME="${APP_NAME}_${VER}_arm64.deb"  ;;
+        esac
+        ;;
+      dnf|yum|rpm)
+        case "$ARCH_NORM" in
+          x86_64) FILENAME="${APP_NAME}-${VER}-1.x86_64.rpm"  ;;
+          arm64)  FILENAME="${APP_NAME}-${VER}-1.aarch64.rpm" ;;
+        esac
+        ;;
     esac
     ;;
 esac
-
-# Where the AppImage is installed on Linux (also read by the final "Done" message).
-LINUX_INSTALL_DIR="$HOME/.local/bin"
 
 DOWNLOAD_URL="${GITHUB_DL}/${VERSION}/${FILENAME}"
 
@@ -189,31 +214,29 @@ case "$PLATFORM" in
     ;;
 
   linux)
-    BIN_DEST="${LINUX_INSTALL_DIR}/picot"
-
-    info "Installing AppImage to ${BIN_DEST}..."
-    mkdir -p "$LINUX_INSTALL_DIR"
-    install -m 755 "$DEST" "$BIN_DEST"
-
-    success "Installed ${APP_NAME}"
-
-    case ":${PATH}:" in
-      *":${LINUX_INSTALL_DIR}:"*) ;;
-      *)
-        warn "${LINUX_INSTALL_DIR} is not on your PATH. Add this to your shell profile:"
-        info "  export PATH=\"${LINUX_INSTALL_DIR}:\$PATH\""
+    case "$PKG_MGR" in
+      apt)
+        info "Installing with apt..."
+        sudo apt-get install -y "$DEST"
+        ;;
+      dpkg)
+        info "Installing with dpkg..."
+        sudo dpkg -i "$DEST"
+        ;;
+      dnf)
+        info "Installing with dnf..."
+        sudo dnf install -y "$DEST"
+        ;;
+      yum)
+        info "Installing with yum..."
+        sudo yum localinstall -y "$DEST"
+        ;;
+      rpm)
+        info "Installing with rpm..."
+        sudo rpm -U --force "$DEST"
         ;;
     esac
-
-    # AppImages need FUSE to mount themselves at launch. Distros that ship
-    # without libfuse2 (e.g. Ubuntu 22.04+, Fedora 36+) fail with "dlopen():
-    # error loading libfuse.so.2" unless it's installed or extract-and-run is
-    # forced instead.
-    if [ ! -e /dev/fuse ] && ! command -v fusermount &>/dev/null && ! command -v fusermount3 &>/dev/null; then
-      warn "FUSE was not detected. If ${APP_NAME} fails to launch, either:"
-      info "  install libfuse2 (e.g. sudo apt install libfuse2), or"
-      info "  run: APPIMAGE_EXTRACT_AND_RUN=1 picot"
-    fi
+    success "Installed ${APP_NAME}"
     ;;
 esac
 
@@ -222,7 +245,7 @@ printf "\n${GREEN}${BOLD}✓ ${APP_NAME} ${VERSION} installed successfully!${RES
 
 case "$PLATFORM" in
   macos) info "Launch it from /Applications/${APP_NAME}.app or Spotlight." ;;
-  linux) info "Launch it by running: picot  (installed to ${LINUX_INSTALL_DIR})" ;;
+  linux) info "Launch it by running: picot  (or search in your app menu)" ;;
 esac
 
 printf "\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,24 +81,6 @@ case "$ARCH" in
   *)                die "Unsupported architecture: $ARCH" ;;
 esac
 
-# ── Detect Linux package manager ──────────────────────────────────────────────
-PKG_MGR=""
-if [ "$PLATFORM" = "linux" ]; then
-  if command -v apt-get &>/dev/null; then
-    PKG_MGR="apt"
-  elif command -v dpkg &>/dev/null; then
-    PKG_MGR="dpkg"
-  elif command -v dnf &>/dev/null; then
-    PKG_MGR="dnf"
-  elif command -v yum &>/dev/null; then
-    PKG_MGR="yum"
-  elif command -v rpm &>/dev/null; then
-    PKG_MGR="rpm"
-  else
-    die "No supported package manager found (apt/dpkg/dnf/yum/rpm)."
-  fi
-fi
-
 # ── Resolve version ───────────────────────────────────────────────────────────
 header "🎯  ${APP_NAME} Installer"
 if is_snap_path "$(command -v curl)"; then
@@ -130,22 +112,15 @@ case "$PLATFORM" in
     esac
     ;;
   linux)
-    case "$PKG_MGR" in
-      apt|dpkg)
-        case "$ARCH_NORM" in
-          x86_64) FILENAME="${APP_NAME}_${VER}_amd64.deb"  ;;
-          arm64)  FILENAME="${APP_NAME}_${VER}_arm64.deb"  ;;
-        esac
-        ;;
-      dnf|yum|rpm)
-        case "$ARCH_NORM" in
-          x86_64) FILENAME="${APP_NAME}-${VER}-1.x86_64.rpm"  ;;
-          arm64)  FILENAME="${APP_NAME}-${VER}-1.aarch64.rpm" ;;
-        esac
-        ;;
+    case "$ARCH_NORM" in
+      x86_64) FILENAME="${APP_NAME}_${VER}_amd64.AppImage"   ;;
+      arm64)  FILENAME="${APP_NAME}_${VER}_aarch64.AppImage" ;;
     esac
     ;;
 esac
+
+# Where the AppImage is installed on Linux (also read by the final "Done" message).
+LINUX_INSTALL_DIR="$HOME/.local/bin"
 
 DOWNLOAD_URL="${GITHUB_DL}/${VERSION}/${FILENAME}"
 
@@ -214,29 +189,31 @@ case "$PLATFORM" in
     ;;
 
   linux)
-    case "$PKG_MGR" in
-      apt)
-        info "Installing with apt..."
-        sudo apt-get install -y "$DEST"
-        ;;
-      dpkg)
-        info "Installing with dpkg..."
-        sudo dpkg -i "$DEST"
-        ;;
-      dnf)
-        info "Installing with dnf..."
-        sudo dnf install -y "$DEST"
-        ;;
-      yum)
-        info "Installing with yum..."
-        sudo yum localinstall -y "$DEST"
-        ;;
-      rpm)
-        info "Installing with rpm..."
-        sudo rpm -U --force "$DEST"
+    BIN_DEST="${LINUX_INSTALL_DIR}/picot"
+
+    info "Installing AppImage to ${BIN_DEST}..."
+    mkdir -p "$LINUX_INSTALL_DIR"
+    install -m 755 "$DEST" "$BIN_DEST"
+
+    success "Installed ${APP_NAME}"
+
+    case ":${PATH}:" in
+      *":${LINUX_INSTALL_DIR}:"*) ;;
+      *)
+        warn "${LINUX_INSTALL_DIR} is not on your PATH. Add this to your shell profile:"
+        info "  export PATH=\"${LINUX_INSTALL_DIR}:\$PATH\""
         ;;
     esac
-    success "Installed ${APP_NAME}"
+
+    # AppImages need FUSE to mount themselves at launch. Distros that ship
+    # without libfuse2 (e.g. Ubuntu 22.04+, Fedora 36+) fail with "dlopen():
+    # error loading libfuse.so.2" unless it's installed or extract-and-run is
+    # forced instead.
+    if [ ! -e /dev/fuse ] && ! command -v fusermount &>/dev/null && ! command -v fusermount3 &>/dev/null; then
+      warn "FUSE was not detected. If ${APP_NAME} fails to launch, either:"
+      info "  install libfuse2 (e.g. sudo apt install libfuse2), or"
+      info "  run: APPIMAGE_EXTRACT_AND_RUN=1 picot"
+    fi
     ;;
 esac
 
@@ -245,7 +222,7 @@ printf "\n${GREEN}${BOLD}✓ ${APP_NAME} ${VERSION} installed successfully!${RES
 
 case "$PLATFORM" in
   macos) info "Launch it from /Applications/${APP_NAME}.app or Spotlight." ;;
-  linux) info "Launch it by running: picot  (or search in your app menu)" ;;
+  linux) info "Launch it by running: picot  (installed to ${LINUX_INSTALL_DIR})" ;;
 esac
 
 printf "\n"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -876,6 +876,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,7 +2031,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2234,6 +2265,59 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -3252,6 +3336,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "portable-pty"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4138,9 +4237,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4148,6 +4247,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -4158,9 +4258,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4578,7 +4678,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]
@@ -5922,7 +6022,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-implement",
  "windows-interface",
 ]
@@ -5946,7 +6046,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6002,7 +6102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6014,7 +6114,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6031,25 +6131,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6094,7 +6181,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -6645,7 +6732,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "picot"
-version = "0.4.3-10002"
+version = "0.4.3-10003"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "picot"
-version = "0.4.3-10001"
+version = "0.4.3-10002"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "picot"
-version = "0.4.2"
+version = "0.4.3-10001"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picot"
-version = "0.4.3-10001"
+version = "0.4.3-10002"
 description = "Pi Agent Desktop - session manager for pi coding agent"
 authors = ["Pi Desktop"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picot"
-version = "0.4.2"
+version = "0.4.3-10001"
 description = "Pi Agent Desktop - session manager for pi coding agent"
 authors = ["Pi Desktop"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picot"
-version = "0.4.3-10002"
+version = "0.4.3-10003"
 description = "Pi Agent Desktop - session manager for pi coding agent"
 authors = ["Pi Desktop"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Picot",
   "identifier": "works.earendil.picot",
-  "version": "0.4.3-10002",
+  "version": "0.4.3-10003",
   "build": {
     "frontendDist": "../public",
     "beforeDevCommand": "bun run fetch:pi && bun run fetch:terminal-font && bun run fetch:cjk-font && bun run build:extensions && bun run build:frontend",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Picot",
   "identifier": "works.earendil.picot",
-  "version": "0.4.2",
+  "version": "0.4.3-10001",
   "build": {
     "frontendDist": "../public",
     "beforeDevCommand": "bun run fetch:pi && bun run fetch:terminal-font && bun run fetch:cjk-font && bun run build:extensions && bun run build:frontend",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Picot",
   "identifier": "works.earendil.picot",
-  "version": "0.4.3-10001",
+  "version": "0.4.3-10002",
   "build": {
     "frontendDist": "../public",
     "beforeDevCommand": "bun run fetch:pi && bun run fetch:terminal-font && bun run fetch:cjk-font && bun run build:extensions && bun run build:frontend",


### PR DESCRIPTION
…web and Picot

- Introduced a comprehensive document comparing the integration of the RPC protocol in pi-web and Picot.
- Detailed the differences in extension binding, command execution, and UI method implementations.
- Highlighted the current limitations in Picot's handling of certain extension functionalities compared to pi-web.
- Provided a roadmap for addressing identified gaps and enhancing Picot's extension capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming message handling so updates display correctly when a response begins without an existing placeholder.

- **New Features**
  - Added an “Enable all” control for skill groups with clearer styling.
  - Linux releases now include AppImage, DEB, and RPM packages.

- **Documentation**
  - Added English and Chinese documentation comparing extension UI support and planned improvements.

- **Release**
  - Updated the application version for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->