### PR TITLE
feat(settings): add custom OpenAI/Anthropic provider setup and provid…

### DIFF
--- a/extensions/custom-provider-probe.test.ts
+++ b/extensions/custom-provider-probe.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildModelsJsonProviderEntry,
+  detectProviderProtocol,
+  mergeProviderIntoModelsJson,
+  normalizeBaseUrl,
+  resolveProviderId,
+  sanitizeProviderId,
+  suggestProviderIdFromBaseUrl,
+  testProviderConnectivity,
+} from "./custom-provider-probe.ts";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("normalizeBaseUrl / sanitizeProviderId", () => {
+  it("normalizes trailing slash and rejects bad schemes", () => {
+    expect(normalizeBaseUrl("https://relay.example.com/v1/")).toBe("https://relay.example.com/v1");
+    expect(() => normalizeBaseUrl("ftp://x")).toThrow(/http/);
+    expect(() => normalizeBaseUrl("not-a-url")).toThrow(/valid/);
+  });
+
+  it("sanitizes provider ids", () => {
+    expect(sanitizeProviderId(" My Relay ")).toBe("my-relay");
+    expect(() => sanitizeProviderId("!!!")).toThrow(/required/);
+  });
+
+  it("suggests and resolves id from base URL when raw is empty or Chinese-only", () => {
+    expect(suggestProviderIdFromBaseUrl("https://api.example.com/v1")).toBe("example-com");
+    expect(resolveProviderId("", "https://relay.foo.io/v1")).toBe("foo-io");
+    expect(resolveProviderId("中转站", "https://api.my-relay.net/v1")).toBe("my-relay-net");
+    expect(resolveProviderId("My Relay", "https://ignored.example/v1")).toBe("my-relay");
+  });
+});
+
+describe("detectProviderProtocol", () => {
+  it("detects OpenAI-compatible /v1/models", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (String(url).includes("/v1/models") && !String(url).includes("messages")) {
+        // first openai probe
+        return jsonResponse({
+          object: "list",
+          data: [
+            {
+              id: "gpt-4o-mini",
+              owned_by: "openai",
+              context_window: 32768,
+              max_output_tokens: 4096,
+            },
+          ],
+        });
+      }
+      return jsonResponse({ error: { type: "not_found_error" } }, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await detectProviderProtocol({
+      baseUrl: "https://relay.example.com/v1",
+      apiKey: "sk-test",
+      fetchImpl,
+    });
+    expect(result.protocol).toBe("openai-completions");
+    expect(result.models.map((m) => m.id)).toContain("gpt-4o-mini");
+    expect(result.models[0]).toMatchObject({ contextWindow: 32768, maxTokens: 4096 });
+    expect(result.confidence).not.toBe("none");
+  });
+
+  it("detects Claude when OpenAI list fails and Anthropic models work", async () => {
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      const headers = (init?.headers || {}) as Record<string, string>;
+      if (u.endsWith("/v1/models") && headers.Authorization) {
+        return jsonResponse({ error: "unauthorized" }, 401);
+      }
+      if (u.endsWith("/v1/models") && headers["x-api-key"]) {
+        return jsonResponse({
+          data: [{ id: "claude-3-5-sonnet-latest", display_name: "Sonnet" }],
+        });
+      }
+      return jsonResponse({ error: "no" }, 404);
+    }) as unknown as typeof fetch;
+
+    const result = await detectProviderProtocol({
+      baseUrl: "https://claude-relay.example.com",
+      apiKey: "sk-ant",
+      fetchImpl,
+    });
+    expect(result.protocol).toBe("anthropic-messages");
+    expect(result.models[0]?.id).toContain("claude");
+  });
+});
+
+describe("testProviderConnectivity", () => {
+  it("treats HTTP 200 chat completions as ok with latency", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ choices: [{ message: { content: "ok" } }] }),
+    ) as unknown as typeof fetch;
+    const result = await testProviderConnectivity({
+      baseUrl: "https://relay.example.com/v1",
+      apiKey: "sk",
+      protocol: "openai-completions",
+      modelId: "gpt-4o-mini",
+      fetchImpl,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(result.endpoint).toContain("/chat/completions");
+  });
+});
+
+describe("models.json merge helpers", () => {
+  it("builds openai entry and merges without clobbering other providers", () => {
+    const entry = buildModelsJsonProviderEntry({
+      baseUrl: "https://relay.example.com/v1",
+      protocol: "openai-completions",
+      models: [
+        "gpt-4o-mini",
+        { id: "deepseek-v3", name: "DeepSeek", contextWindow: 65536, maxTokens: 8192 },
+      ],
+    });
+    expect(entry.api).toBe("openai-completions");
+    expect(entry.compat).toMatchObject({
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStore: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
+    });
+    expect(entry.authHeader).toBe(true);
+    expect(entry.models[0]).toMatchObject({
+      id: "gpt-4o-mini",
+      contextWindow: 128000,
+      maxTokens: 16384,
+    });
+    expect(entry.models[1]).toMatchObject({
+      id: "deepseek-v3",
+      contextWindow: 65536,
+      maxTokens: 8192,
+    });
+    const merged = mergeProviderIntoModelsJson(
+      {
+        providers: {
+          ollama: { baseUrl: "http://localhost:11434/v1", api: "openai-completions", models: [] },
+        },
+      },
+      "My Relay",
+      entry,
+    );
+    expect(Object.keys(merged.providers || {}).sort()).toEqual(["my-relay", "ollama"]);
+    expect(merged.providers?.["my-relay"]?.models.map((m) => m.id)).toEqual([
+      "gpt-4o-mini",
+      "deepseek-v3",
+    ]);
+  });
+
+  it("fills Claude defaults for anthropic protocol models", () => {
+    const entry = buildModelsJsonProviderEntry({
+      baseUrl: "https://api.relay.example",
+      protocol: "anthropic-messages",
+      models: ["claude-sonnet-4-6"],
+    });
+    expect(entry.api).toBe("anthropic-messages");
+    expect(entry.models[0]).toMatchObject({
+      id: "claude-sonnet-4-6",
+      reasoning: true,
+      contextWindow: 200000,
+      maxTokens: 8192,
+    });
+  });
+
+  it("drops Groq non-chat catalog entries and sets session-safe OpenAI compat", () => {
+    const entry = buildModelsJsonProviderEntry({
+      baseUrl: "https://api.groq.com/openai/v1",
+      protocol: "openai-completions",
+      models: [
+        {
+          id: "whisper-large-v3",
+          name: "Whisper",
+          contextWindow: 448,
+          maxTokens: 16384,
+        },
+        {
+          id: "meta-llama/llama-prompt-guard-2-86m",
+          contextWindow: 512,
+          maxTokens: 16384,
+        },
+        {
+          id: "openai/gpt-oss-120b",
+          name: "GPT OSS 120B",
+          contextWindow: 131072,
+          maxTokens: 16384,
+        },
+      ],
+    });
+    expect(entry.models.map((m) => m.id)).toEqual(["openai/gpt-oss-120b"]);
+    expect(entry.models[0]).toMatchObject({
+      reasoning: true,
+      maxTokens: 2048,
+      thinkingLevelMap: { low: "low", medium: "medium", high: "high" },
+    });
+    expect(entry.compat).toMatchObject({
+      supportsStore: false,
+      supportsStrictMode: false,
+      supportsReasoningEffort: false,
+      maxTokensField: "max_completion_tokens",
+    });
+    expect(entry.models[0].compat).toMatchObject({ supportsReasoningEffort: true });
+  });
+});

--- a/extensions/custom-provider-probe.ts
+++ b/extensions/custom-provider-probe.ts
@@ -1,0 +1,925 @@
+/**
+ * Custom / relay model-provider probe helpers.
+ *
+ * Used by Settings → Configuration custom-provider setup to:
+ * - auto-detect OpenAI-compatible vs Claude/Anthropic protocols
+ * - list upstream models
+ * - measure connectivity latency
+ * - merge a provider entry into ~/.pi/agent/models.json
+ *
+ * Pure-ish network helpers — inject `fetchImpl` in tests.
+ */
+
+export type ProviderProtocol = "openai-completions" | "anthropic-messages";
+
+export type ProbeModel = {
+  id: string;
+  name?: string;
+  ownedBy?: string;
+  /** Context-window tokens advertised by the upstream relay, when supplied. */
+  contextWindow?: number;
+  /** Maximum output tokens advertised by the upstream relay, when supplied. */
+  maxTokens?: number;
+};
+
+export type ProtocolProbeAttempt = {
+  protocol: ProviderProtocol;
+  ok: boolean;
+  status?: number;
+  latencyMs: number;
+  endpoint: string;
+  error?: string;
+  models?: ProbeModel[];
+};
+
+export type ProtocolProbeResult = {
+  baseUrl: string;
+  protocol: ProviderProtocol | "unknown";
+  confidence: "high" | "medium" | "low" | "none";
+  latencyMs?: number;
+  models: ProbeModel[];
+  attempts: ProtocolProbeAttempt[];
+  error?: string;
+};
+
+export type ConnectivityProbeResult = {
+  ok: boolean;
+  protocol: ProviderProtocol;
+  latencyMs: number;
+  endpoint: string;
+  status?: number;
+  error?: string;
+};
+
+export type ModelsJsonProvider = {
+  baseUrl: string;
+  api: ProviderProtocol;
+  apiKey?: string;
+  authHeader?: boolean;
+  models: Array<{
+    id: string;
+    name?: string;
+    reasoning?: boolean;
+    input?: string[];
+    contextWindow?: number;
+    maxTokens?: number;
+    cost?: Record<string, number>;
+    thinkingLevelMap?: Record<string, string | null>;
+    compat?: Record<string, unknown>;
+  }>;
+  compat?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type ModelsJsonDocument = {
+  providers?: Record<string, ModelsJsonProvider>;
+  [key: string]: unknown;
+};
+
+type FetchLike = typeof fetch;
+
+const OPENAI_COMPAT_HINTS = [
+  "openai",
+  "gpt-",
+  "o1",
+  "o3",
+  "deepseek",
+  "qwen",
+  "glm",
+  "moonshot",
+  "doubao",
+  "yi-",
+  "llama",
+  "mistral",
+  "gemini",
+];
+
+const CLAUDE_HINTS = ["claude", "anthropic", "haiku", "sonnet", "opus"];
+
+/** Audio / classifier / TTS ids that Groq (and similar catalogs) mix into /v1/models. */
+const NON_CHAT_MODEL_HINTS = [
+  "whisper",
+  "tts",
+  "orpheus",
+  "prompt-guard",
+  "playai",
+  "distil-whisper",
+  "canopylabs/",
+];
+
+const REASONING_MODEL_HINTS = ["gpt-oss", "o1", "o3", "o4", "/compound"];
+
+const DEFAULT_OPENAI_MAX_TOKENS = 16384;
+/** Groq on_demand TPM is a per-request ceiling; max_completion_tokens counts against it. */
+const GROQ_CHAT_MAX_OUTPUT_TOKENS = 2048;
+/** gpt-oss still needs headroom for reasoning, but 32k blows Groq's 8k free TPM. */
+const GROQ_REASONING_MAX_OUTPUT_TOKENS = 2048;
+const MIN_AGENT_CONTEXT_WINDOW = 2048;
+
+export function isLikelyNonChatModel(id: string, contextWindow?: number): boolean {
+  const hay = String(id || "").toLowerCase();
+  if (!hay) return true;
+  if (NON_CHAT_MODEL_HINTS.some((hint) => hay.includes(hint))) return true;
+  if (contextWindow && contextWindow > 0 && contextWindow < MIN_AGENT_CONTEXT_WINDOW) return true;
+  return false;
+}
+
+function looksReasoningModel(id: string): boolean {
+  const hay = String(id || "").toLowerCase();
+  return REASONING_MODEL_HINTS.some((hint) => hay.includes(hint));
+}
+
+function isGroqBaseUrl(baseUrl: string): boolean {
+  return /groq\.com/i.test(baseUrl);
+}
+
+/**
+ * Custom OpenAI-compatible hosts are not api.openai.com.
+ * Pi auto-detects unknown hosts as full OpenAI and sends `store` / `strict`,
+ * which Groq and most relays reject (health check still passes because it
+ * only sends a tiny un-tooled ping).
+ */
+function openaiCompletionsCompat(baseUrl: string): Record<string, unknown> {
+  const groq = isGroqBaseUrl(baseUrl);
+  return {
+    supportsDeveloperRole: false,
+    supportsReasoningEffort: false,
+    supportsStore: false,
+    supportsStrictMode: false,
+    supportsLongCacheRetention: false,
+    maxTokensField: groq ? "max_completion_tokens" : "max_tokens",
+  };
+}
+
+function groqMaxOutputTokens(id: string): number {
+  return looksReasoningModel(id) ? GROQ_REASONING_MAX_OUTPUT_TOKENS : GROQ_CHAT_MAX_OUTPUT_TOKENS;
+}
+
+function groqThinkingLevelMap(id: string): Record<string, string> | undefined {
+  if (!looksReasoningModel(id)) return undefined;
+  // Groq gpt-oss only accepts low | medium | high (no off/none).
+  return {
+    off: "low",
+    minimal: "low",
+    low: "low",
+    medium: "medium",
+    high: "high",
+    xhigh: "high",
+    max: "high",
+  };
+}
+
+export function normalizeBaseUrl(raw: string): string {
+  const trimmed = String(raw || "").trim();
+  if (!trimmed) throw new Error("baseUrl is required");
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error("baseUrl must be a valid absolute URL (http/https)");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("baseUrl must use http or https");
+  }
+  // Drop trailing slash; keep path prefix used by many Chinese relay stations.
+  url.hash = "";
+  url.search = "";
+  let href = url.toString();
+  if (href.endsWith("/")) href = href.slice(0, -1);
+  return href;
+}
+
+/**
+ * Normalize a provider id for models.json / auth.json keys.
+ * Only [a-z0-9._-] are kept. Empty after sanitize is an error — callers that
+ * want auto-id should use resolveProviderId(raw, baseUrl).
+ */
+export function sanitizeProviderId(raw: string): string {
+  const id = String(raw || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/\.{2,}/g, ".")
+    .replace(/-{2,}/g, "-");
+  if (!id) throw new Error("provider id is required");
+  if (id.length > 64) throw new Error("provider id is too long (max 64)");
+  return id;
+}
+
+/**
+ * Derive a stable provider id from a relay base URL host (e.g. api.xxx.com → api-xxx-com).
+ */
+export function suggestProviderIdFromBaseUrl(baseUrl: string): string {
+  let host = "";
+  try {
+    host = new URL(normalizeBaseUrl(baseUrl)).hostname || "";
+  } catch {
+    host = String(baseUrl || "")
+      .replace(/^https?:\/\//i, "")
+      .split("/")[0]
+      .split(":")[0];
+  }
+  host = host
+    .toLowerCase()
+    .replace(/^www\./, "")
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!host) return "custom-relay";
+  // Prefer last two DNS labels when long (api.foo.example.com → example-com)
+  const parts = host.split(".").filter(Boolean);
+  let slug = parts.length >= 2 ? `${parts[parts.length - 2]}-${parts[parts.length - 1]}` : host;
+  slug = slug.replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  if (!slug) slug = "custom-relay";
+  if (slug.length > 48) slug = slug.slice(0, 48).replace(/-+$/g, "");
+  return slug;
+}
+
+/**
+ * Resolve provider id: use raw when it sanitizes cleanly; otherwise fall back to baseUrl host.
+ * Chinese-only names are not valid models.json keys — auto-derive instead of failing opaquely.
+ */
+export function resolveProviderId(raw: string | undefined, baseUrl?: string): string {
+  const trimmed = String(raw || "").trim();
+  if (trimmed) {
+    try {
+      return sanitizeProviderId(trimmed);
+    } catch {
+      // fall through to baseUrl / default
+    }
+  }
+  if (baseUrl && String(baseUrl).trim()) {
+    return sanitizeProviderId(suggestProviderIdFromBaseUrl(baseUrl));
+  }
+  throw new Error(
+    "provider id is required (use English letters/numbers, or leave blank to auto-fill from Base URL)",
+  );
+}
+
+function joinUrl(baseUrl: string, pathPart: string): string {
+  const base = baseUrl.replace(/\/+$/, "");
+  const part = pathPart.startsWith("/") ? pathPart : `/${pathPart}`;
+  // Avoid double /v1/v1 when user already ends with /v1
+  if (base.endsWith("/v1") && part.startsWith("/v1/")) {
+    return `${base}${part.slice(3)}`;
+  }
+  return `${base}${part}`;
+}
+
+function openaiAuthHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+}
+
+function anthropicAuthHeaders(apiKey: string): Record<string, string> {
+  return {
+    "x-api-key": apiKey,
+    "anthropic-version": "2023-06-01",
+    "Content-Type": "application/json",
+  };
+}
+
+function positiveTokenLimit(value: unknown): number | undefined {
+  const parsed =
+    typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined;
+}
+
+function modelTokenLimit(item: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = positiveTokenLimit(item[key]);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+function parseOpenAiModels(payload: unknown): ProbeModel[] {
+  if (!payload || typeof payload !== "object") return [];
+  const data = (payload as { data?: unknown }).data;
+  if (!Array.isArray(data)) return [];
+  const models: ProbeModel[] = [];
+  for (const item of data) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+    const id = record.id;
+    if (typeof id !== "string" || !id.trim()) continue;
+    if (isLikelyNonChatModel(id.trim())) continue;
+    const name =
+      typeof record.name === "string"
+        ? record.name
+        : typeof record.display_name === "string"
+          ? record.display_name
+          : undefined;
+    const ownedBy = typeof record.owned_by === "string" ? record.owned_by : undefined;
+    const contextWindow = modelTokenLimit(record, [
+      "context_window",
+      "contextWindow",
+      "context_length",
+      "contextLength",
+      "max_context_tokens",
+      "maxContextTokens",
+    ]);
+    const maxTokens = modelTokenLimit(record, [
+      "max_output_tokens",
+      "maxOutputTokens",
+      "max_tokens",
+      "maxTokens",
+      "output_token_limit",
+      "outputTokenLimit",
+    ]);
+    models.push({
+      id: id.trim(),
+      name,
+      ownedBy,
+      ...(contextWindow ? { contextWindow } : {}),
+      ...(maxTokens ? { maxTokens } : {}),
+    });
+  }
+  return models.filter((model) => !isLikelyNonChatModel(model.id, model.contextWindow));
+}
+
+function parseAnthropicModels(payload: unknown): ProbeModel[] {
+  // Anthropic official: { data: [{ id, display_name, ... }] }
+  const fromData = parseOpenAiModels(payload);
+  if (fromData.length > 0) return fromData;
+  if (!payload || typeof payload !== "object") return [];
+  const models = (payload as { models?: unknown }).models;
+  if (!Array.isArray(models)) return [];
+  const out: ProbeModel[] = [];
+  for (const item of models) {
+    if (typeof item === "string" && item.trim()) {
+      out.push({ id: item.trim() });
+      continue;
+    }
+    if (!item || typeof item !== "object") continue;
+    const id =
+      typeof (item as { id?: unknown }).id === "string"
+        ? (item as { id: string }).id
+        : typeof (item as { name?: unknown }).name === "string"
+          ? (item as { name: string }).name
+          : "";
+    if (!id.trim()) continue;
+    const record = item as Record<string, unknown>;
+    const name =
+      typeof record.display_name === "string"
+        ? record.display_name
+        : typeof record.name === "string"
+          ? record.name
+          : undefined;
+    const contextWindow = modelTokenLimit(record, [
+      "context_window",
+      "contextWindow",
+      "context_length",
+      "contextLength",
+      "max_context_tokens",
+    ]);
+    const maxTokens = modelTokenLimit(record, [
+      "max_output_tokens",
+      "maxOutputTokens",
+      "max_tokens",
+      "maxTokens",
+      "output_token_limit",
+    ]);
+    out.push({
+      id: id.trim(),
+      name,
+      ...(contextWindow ? { contextWindow } : {}),
+      ...(maxTokens ? { maxTokens } : {}),
+    });
+  }
+  return out;
+}
+
+function scoreProtocolFromModels(models: ProbeModel[], preferred: ProviderProtocol): number {
+  if (models.length === 0) return preferred === "openai-completions" ? 1 : 0;
+  let openaiHits = 0;
+  let claudeHits = 0;
+  for (const model of models) {
+    const hay = `${model.id} ${model.name || ""} ${model.ownedBy || ""}`.toLowerCase();
+    if (CLAUDE_HINTS.some((h) => hay.includes(h))) claudeHits += 1;
+    if (OPENAI_COMPAT_HINTS.some((h) => hay.includes(h))) openaiHits += 1;
+  }
+  if (preferred === "anthropic-messages") {
+    return claudeHits * 3 + (models.length > 0 ? 1 : 0) - openaiHits;
+  }
+  return openaiHits * 2 + (models.length > 0 ? 2 : 0) - claudeHits;
+}
+
+async function timedFetch(
+  fetchImpl: FetchLike,
+  url: string,
+  init: RequestInit,
+  timeoutMs = 15000,
+): Promise<{ response?: Response; latencyMs: number; error?: string }> {
+  const started = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, { ...init, signal: controller.signal });
+    return { response, latencyMs: Date.now() - started };
+  } catch (e: unknown) {
+    const message =
+      e instanceof Error
+        ? e.name === "AbortError"
+          ? `Request timed out after ${timeoutMs}ms`
+          : e.message
+        : String(e);
+    return { latencyMs: Date.now() - started, error: message };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function probeOpenAi(
+  baseUrl: string,
+  apiKey: string,
+  fetchImpl: FetchLike,
+): Promise<ProtocolProbeAttempt> {
+  const endpoint = joinUrl(baseUrl, "/v1/models");
+  const { response, latencyMs, error } = await timedFetch(fetchImpl, endpoint, {
+    method: "GET",
+    headers: openaiAuthHeaders(apiKey),
+  });
+  if (error || !response) {
+    return {
+      protocol: "openai-completions",
+      ok: false,
+      latencyMs,
+      endpoint,
+      error: error || "No response",
+    };
+  }
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    return {
+      protocol: "openai-completions",
+      ok: false,
+      status: response.status,
+      latencyMs,
+      endpoint,
+      error: body.slice(0, 240) || `HTTP ${response.status}`,
+    };
+  }
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    return {
+      protocol: "openai-completions",
+      ok: false,
+      status: response.status,
+      latencyMs,
+      endpoint,
+      error: "Response is not JSON",
+    };
+  }
+  const models = parseOpenAiModels(payload);
+  // Some relays return 200 with non-list bodies for wrong protocol.
+  if (models.length === 0 && !(payload as { object?: string })?.object) {
+    return {
+      protocol: "openai-completions",
+      ok: false,
+      status: response.status,
+      latencyMs,
+      endpoint,
+      error: "No OpenAI-style model list in response",
+      models: [],
+    };
+  }
+  return {
+    protocol: "openai-completions",
+    ok: true,
+    status: response.status,
+    latencyMs,
+    endpoint,
+    models,
+  };
+}
+
+async function probeAnthropic(
+  baseUrl: string,
+  apiKey: string,
+  fetchImpl: FetchLike,
+): Promise<ProtocolProbeAttempt> {
+  // Prefer /v1/models (official + many relays). Fall back to a tiny messages
+  // probe when the models endpoint is missing.
+  const modelsEndpoint = joinUrl(baseUrl, "/v1/models");
+  const modelsAttempt = await timedFetch(fetchImpl, modelsEndpoint, {
+    method: "GET",
+    headers: anthropicAuthHeaders(apiKey),
+  });
+
+  if (modelsAttempt.response?.ok) {
+    try {
+      const payload = await modelsAttempt.response.json();
+      const models = parseAnthropicModels(payload);
+      if (models.length > 0) {
+        return {
+          protocol: "anthropic-messages",
+          ok: true,
+          status: modelsAttempt.response.status,
+          latencyMs: modelsAttempt.latencyMs,
+          endpoint: modelsEndpoint,
+          models,
+        };
+      }
+    } catch {
+      // fall through to messages probe
+    }
+  }
+
+  const messagesEndpoint = joinUrl(baseUrl, "/v1/messages");
+  const messagesAttempt = await timedFetch(fetchImpl, messagesEndpoint, {
+    method: "POST",
+    headers: anthropicAuthHeaders(apiKey),
+    body: JSON.stringify({
+      model: "claude-3-5-haiku-latest",
+      max_tokens: 1,
+      messages: [{ role: "user", content: "ping" }],
+    }),
+  });
+
+  if (messagesAttempt.error || !messagesAttempt.response) {
+    const status = modelsAttempt.response?.status;
+    const err =
+      messagesAttempt.error ||
+      (modelsAttempt.response
+        ? `Models HTTP ${modelsAttempt.response.status}; messages failed`
+        : modelsAttempt.error) ||
+      "No response";
+    return {
+      protocol: "anthropic-messages",
+      ok: false,
+      status,
+      latencyMs: messagesAttempt.latencyMs || modelsAttempt.latencyMs,
+      endpoint: messagesEndpoint,
+      error: err,
+    };
+  }
+
+  // Auth/protocol success signals: 200, or 400/404 with anthropic-shaped error
+  // (wrong model id still proves Claude protocol).
+  const status = messagesAttempt.response.status;
+  let bodyText = "";
+  try {
+    bodyText = await messagesAttempt.response.text();
+  } catch {
+    bodyText = "";
+  }
+  let payload: unknown;
+  try {
+    payload = bodyText ? JSON.parse(bodyText) : undefined;
+  } catch {
+    payload = undefined;
+  }
+  const looksAnthropic =
+    status === 200 ||
+    (typeof bodyText === "string" &&
+      (bodyText.includes("type") ||
+        bodyText.includes("anthropic") ||
+        bodyText.includes("claude"))) ||
+    (payload &&
+      typeof payload === "object" &&
+      ("type" in (payload as object) || "error" in (payload as object)));
+
+  if (!looksAnthropic && status >= 500) {
+    return {
+      protocol: "anthropic-messages",
+      ok: false,
+      status,
+      latencyMs: messagesAttempt.latencyMs,
+      endpoint: messagesEndpoint,
+      error: bodyText.slice(0, 240) || `HTTP ${status}`,
+    };
+  }
+
+  if (!looksAnthropic && (status === 401 || status === 403)) {
+    return {
+      protocol: "anthropic-messages",
+      ok: false,
+      status,
+      latencyMs: messagesAttempt.latencyMs,
+      endpoint: messagesEndpoint,
+      error: bodyText.slice(0, 240) || `HTTP ${status}`,
+    };
+  }
+
+  // 401 on anthropic headers against OpenAI endpoints is common; only accept
+  // if models probe already hinted anthropic OR body looks anthropic.
+  if (!looksAnthropic) {
+    return {
+      protocol: "anthropic-messages",
+      ok: false,
+      status,
+      latencyMs: messagesAttempt.latencyMs,
+      endpoint: messagesEndpoint,
+      error: bodyText.slice(0, 240) || `HTTP ${status}`,
+    };
+  }
+
+  return {
+    protocol: "anthropic-messages",
+    ok: status < 500,
+    status,
+    latencyMs: messagesAttempt.latencyMs,
+    endpoint: messagesEndpoint,
+    models: [],
+    error: status >= 400 ? bodyText.slice(0, 240) || `HTTP ${status}` : undefined,
+  };
+}
+
+export async function detectProviderProtocol(options: {
+  baseUrl: string;
+  apiKey: string;
+  fetchImpl?: FetchLike;
+  preferred?: ProviderProtocol | "auto";
+}): Promise<ProtocolProbeResult> {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const apiKey = String(options.apiKey || "").trim();
+  if (!apiKey) {
+    return {
+      baseUrl,
+      protocol: "unknown",
+      confidence: "none",
+      models: [],
+      attempts: [],
+      error: "apiKey is required",
+    };
+  }
+  const fetchImpl = options.fetchImpl || fetch;
+  const preferred = options.preferred || "auto";
+
+  const order: ProviderProtocol[] =
+    preferred === "anthropic-messages"
+      ? ["anthropic-messages", "openai-completions"]
+      : preferred === "openai-completions"
+        ? ["openai-completions", "anthropic-messages"]
+        : ["openai-completions", "anthropic-messages"];
+
+  const attempts: ProtocolProbeAttempt[] = [];
+  for (const protocol of order) {
+    const attempt =
+      protocol === "openai-completions"
+        ? await probeOpenAi(baseUrl, apiKey, fetchImpl)
+        : await probeAnthropic(baseUrl, apiKey, fetchImpl);
+    attempts.push(attempt);
+  }
+
+  const scored = attempts
+    .map((attempt) => ({
+      attempt,
+      score:
+        (attempt.ok ? 10 : 0) +
+        scoreProtocolFromModels(attempt.models || [], attempt.protocol) +
+        (attempt.models && attempt.models.length > 0 ? 5 : 0) -
+        // Prefer faster ok attempt slightly
+        (attempt.ok ? Math.min(attempt.latencyMs, 5000) / 5000 : 0),
+    }))
+    .sort((a, b) => b.score - a.score);
+
+  const best = scored[0];
+  if (!best || best.score < 5) {
+    return {
+      baseUrl,
+      protocol: "unknown",
+      confidence: "none",
+      models: [],
+      attempts,
+      error:
+        attempts
+          .map((a) => a.error)
+          .filter(Boolean)
+          .join(" | ") || "Could not detect OpenAI or Claude protocol",
+    };
+  }
+
+  const models = best.attempt.models || [];
+  const confidence: ProtocolProbeResult["confidence"] =
+    best.score >= 16 ? "high" : best.score >= 10 ? "medium" : "low";
+
+  return {
+    baseUrl,
+    protocol: best.attempt.protocol,
+    confidence,
+    latencyMs: best.attempt.latencyMs,
+    models,
+    attempts,
+  };
+}
+
+export async function fetchUpstreamModels(options: {
+  baseUrl: string;
+  apiKey: string;
+  protocol: ProviderProtocol;
+  fetchImpl?: FetchLike;
+}): Promise<{ models: ProbeModel[]; latencyMs: number; endpoint: string }> {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const apiKey = String(options.apiKey || "").trim();
+  if (!apiKey) throw new Error("apiKey is required");
+  const fetchImpl = options.fetchImpl || fetch;
+  const attempt =
+    options.protocol === "anthropic-messages"
+      ? await probeAnthropic(baseUrl, apiKey, fetchImpl)
+      : await probeOpenAi(baseUrl, apiKey, fetchImpl);
+  if (!attempt.ok && (!attempt.models || attempt.models.length === 0)) {
+    throw new Error(attempt.error || `Failed to list models (${attempt.protocol})`);
+  }
+  return {
+    models: attempt.models || [],
+    latencyMs: attempt.latencyMs,
+    endpoint: attempt.endpoint,
+  };
+}
+
+export async function testProviderConnectivity(options: {
+  baseUrl: string;
+  apiKey: string;
+  protocol: ProviderProtocol;
+  modelId?: string;
+  fetchImpl?: FetchLike;
+}): Promise<ConnectivityProbeResult> {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const apiKey = String(options.apiKey || "").trim();
+  if (!apiKey) {
+    return {
+      ok: false,
+      protocol: options.protocol,
+      latencyMs: 0,
+      endpoint: baseUrl,
+      error: "apiKey is required",
+    };
+  }
+  const fetchImpl = options.fetchImpl || fetch;
+
+  if (options.protocol === "openai-completions") {
+    const model = options.modelId || "gpt-4o-mini";
+    const endpoint = joinUrl(baseUrl, "/v1/chat/completions");
+    const { response, latencyMs, error } = await timedFetch(fetchImpl, endpoint, {
+      method: "POST",
+      headers: openaiAuthHeaders(apiKey),
+      body: JSON.stringify({
+        model,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "ping" }],
+      }),
+    });
+    if (error || !response) {
+      return {
+        ok: false,
+        protocol: options.protocol,
+        latencyMs,
+        endpoint,
+        error: error || "No response",
+      };
+    }
+    // 200 = full success; 400 often means auth+route ok but model id wrong.
+    const ok = response.status < 500 && response.status !== 401 && response.status !== 403;
+    let errText: string | undefined;
+    if (!ok || response.status >= 400) {
+      errText = (await response.text().catch(() => "")).slice(0, 240) || `HTTP ${response.status}`;
+    }
+    return {
+      ok,
+      protocol: options.protocol,
+      latencyMs,
+      endpoint,
+      status: response.status,
+      error: ok ? undefined : errText,
+    };
+  }
+
+  const model = options.modelId || "claude-3-5-haiku-latest";
+  const endpoint = joinUrl(baseUrl, "/v1/messages");
+  const { response, latencyMs, error } = await timedFetch(fetchImpl, endpoint, {
+    method: "POST",
+    headers: anthropicAuthHeaders(apiKey),
+    body: JSON.stringify({
+      model,
+      max_tokens: 1,
+      messages: [{ role: "user", content: "ping" }],
+    }),
+  });
+  if (error || !response) {
+    return {
+      ok: false,
+      protocol: options.protocol,
+      latencyMs,
+      endpoint,
+      error: error || "No response",
+    };
+  }
+  const ok = response.status < 500 && response.status !== 401 && response.status !== 403;
+  let errText: string | undefined;
+  if (!ok || response.status >= 400) {
+    errText = (await response.text().catch(() => "")).slice(0, 240) || `HTTP ${response.status}`;
+  }
+  return {
+    ok,
+    protocol: options.protocol,
+    latencyMs,
+    endpoint,
+    status: response.status,
+    error: ok ? undefined : errText,
+  };
+}
+
+export function buildModelsJsonProviderEntry(options: {
+  baseUrl: string;
+  protocol: ProviderProtocol;
+  models: Array<string | ProbeModel>;
+  apiKey?: string;
+  includeApiKeyInFile?: boolean;
+}): ModelsJsonProvider {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  // Full model defaults improve relay reliability (context/maxTokens/cost).
+  // Minimal `{ id }` works for Ollama, but some Claude/OpenAI proxies behave
+  // better with explicit windows — match pi docs "Full Example".
+  const models = options.models
+    .map((m) => {
+      const id = typeof m === "string" ? m.trim() : String(m.id || "").trim();
+      if (!id) return null;
+      const advertisedContext = typeof m === "string" ? undefined : m.contextWindow;
+      if (
+        options.protocol === "openai-completions" &&
+        isLikelyNonChatModel(id, advertisedContext)
+      ) {
+        return null;
+      }
+      const name = typeof m === "string" ? undefined : m.name ? String(m.name) : undefined;
+      const looksClaude = /claude|opus|sonnet|haiku|anthropic/i.test(id);
+      const contextWindow =
+        typeof m === "string"
+          ? looksClaude
+            ? 200000
+            : 128000
+          : m.contextWindow || (looksClaude ? 200000 : 128000);
+      let maxTokens =
+        typeof m === "string"
+          ? looksClaude
+            ? 8192
+            : DEFAULT_OPENAI_MAX_TOKENS
+          : m.maxTokens || (looksClaude ? 8192 : DEFAULT_OPENAI_MAX_TOKENS);
+      if (isGroqBaseUrl(baseUrl)) {
+        maxTokens = looksReasoningModel(id)
+          ? Math.min(groqMaxOutputTokens(id), contextWindow)
+          : Math.min(maxTokens, groqMaxOutputTokens(id), contextWindow);
+      } else {
+        maxTokens = Math.min(maxTokens, contextWindow);
+      }
+      const thinkingLevelMap = isGroqBaseUrl(baseUrl) ? groqThinkingLevelMap(id) : undefined;
+      return {
+        id,
+        ...(name ? { name } : {}),
+        reasoning:
+          looksClaude || looksReasoningModel(id) || options.protocol === "anthropic-messages",
+        input: ["text"] as string[],
+        // Preserve upstream relay metadata whenever it advertises token limits.
+        // Defaults remain only for incomplete /v1/models responses.
+        contextWindow,
+        maxTokens,
+        ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
+        ...(isGroqBaseUrl(baseUrl) && looksReasoningModel(id)
+          ? { compat: { supportsReasoningEffort: true } }
+          : {}),
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      };
+    })
+    .filter((m): m is NonNullable<typeof m> => Boolean(m));
+  if (models.length === 0) {
+    throw new Error("At least one model id is required");
+  }
+  const entry: ModelsJsonProvider = {
+    baseUrl,
+    api: options.protocol,
+    models,
+  };
+  if (options.protocol === "openai-completions") {
+    entry.compat = openaiCompletionsCompat(baseUrl);
+    entry.authHeader = true;
+  }
+  if (options.includeApiKeyInFile && options.apiKey) {
+    entry.apiKey = options.apiKey;
+  }
+  return entry;
+}
+
+export function mergeProviderIntoModelsJson(
+  existing: unknown,
+  providerId: string,
+  entry: ModelsJsonProvider,
+): ModelsJsonDocument {
+  const id = sanitizeProviderId(providerId);
+  const doc: ModelsJsonDocument =
+    existing && typeof existing === "object" && !Array.isArray(existing)
+      ? { ...(existing as ModelsJsonDocument) }
+      : { providers: {} };
+  const providers =
+    doc.providers && typeof doc.providers === "object" && !Array.isArray(doc.providers)
+      ? { ...doc.providers }
+      : {};
+  providers[id] = entry;
+  doc.providers = providers;
+  return doc;
+}

--- a/extensions/picot-config.test.ts
+++ b/extensions/picot-config.test.ts
@@ -274,3 +274,126 @@ describe("picot config auth operations", () => {
     expect(registry.refresh).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("picot config custom provider operations", () => {
+  it("saves a relay provider into models.json and stores the API key", async () => {
+    const { home, handlePicotConfig } = await loadConfigWithTempHome();
+    const credentials = {
+      modify: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    };
+    const registry = {
+      runtime: { credentials },
+      refresh: vi.fn(async () => undefined),
+    };
+
+    const result = await handlePicotConfig(
+      "save_custom_provider",
+      {
+        providerId: "My Relay",
+        baseUrl: "https://relay.example.com/v1",
+        apiKey: "sk-test",
+        protocol: "openai-completions",
+        models: [{ id: "gpt-4o-mini", contextWindow: 32768, maxTokens: 4096 }],
+      },
+      { modelRegistry: registry },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        providerId: "my-relay",
+        protocol: "openai-completions",
+        modelCount: 1,
+        keyStored: true,
+      },
+    });
+    const saved = JSON.parse(readFileSync(join(home, ".pi", "agent", "models.json"), "utf8"));
+    expect(saved.providers["my-relay"]).toMatchObject({
+      baseUrl: "https://relay.example.com/v1",
+      api: "openai-completions",
+      models: [
+        expect.objectContaining({ id: "gpt-4o-mini", contextWindow: 32768, maxTokens: 4096 }),
+      ],
+    });
+    expect(saved.providers["my-relay"].apiKey).toBeUndefined();
+    expect(credentials.modify).toHaveBeenCalledWith("my-relay", expect.any(Function));
+  });
+
+  it("detects an OpenAI-compatible relay", async () => {
+    const { handlePicotConfig } = await loadConfigWithTempHome();
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (String(url).includes("/v1/models")) {
+        return new Response(
+          JSON.stringify({
+            object: "list",
+            data: [{ id: "gpt-4o-mini", context_window: 32768 }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("{}", { status: 404 });
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchImpl as unknown as typeof fetch;
+    try {
+      const result = await handlePicotConfig(
+        "detect_custom_provider",
+        { baseUrl: "https://relay.example.com/v1", apiKey: "sk-test" },
+        {},
+      );
+      expect(result.ok).toBe(true);
+      expect(result).toMatchObject({
+        data: {
+          protocol: "openai-completions",
+          models: [expect.objectContaining({ id: "gpt-4o-mini" })],
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("health-checks custom providers over HTTP instead of creating an agent session", async () => {
+    const { handlePicotConfig } = await loadConfigWithTempHome();
+    const { createAgentSession } = await import("@earendil-works/pi-coding-agent");
+    const fetchImpl = vi.fn(async () => {
+      return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchImpl as unknown as typeof fetch;
+    const registry = {
+      getAll: () => [
+        {
+          provider: "my-relay",
+          id: "gpt-4o-mini",
+          api: "openai-completions",
+          baseUrl: "https://relay.example.com/v1",
+        },
+      ],
+      getAvailable: async () => [{ provider: "my-relay", id: "gpt-4o-mini" }],
+      getProviderAuthStatus: () => ({ configured: true }),
+      getProviderDisplayName: () => "my-relay",
+      refresh: vi.fn(),
+      getApiKeyForProvider: async () => "sk-test",
+    };
+    try {
+      const result = await handlePicotConfig(
+        "check_model_health",
+        { provider: "my-relay", modelId: "gpt-4o-mini" },
+        { modelRegistry: registry },
+      );
+      expect(result.ok).toBe(true);
+      expect(result).toMatchObject({
+        data: { results: [expect.objectContaining({ provider: "my-relay", status: "healthy" })] },
+      });
+      expect(createAgentSession).not.toHaveBeenCalled();
+      expect(fetchImpl).toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/extensions/picot-config.ts
+++ b/extensions/picot-config.ts
@@ -18,6 +18,18 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createAgentSession, ModelRuntime, SessionManager } from "@earendil-works/pi-coding-agent";
+import {
+  buildModelsJsonProviderEntry,
+  detectProviderProtocol,
+  fetchUpstreamModels,
+  type ModelsJsonDocument,
+  mergeProviderIntoModelsJson,
+  normalizeBaseUrl,
+  type ProbeModel,
+  type ProviderProtocol,
+  resolveProviderId,
+  testProviderConnectivity,
+} from "./custom-provider-probe";
 import { buildPackageSkillInventory } from "./package-skill-inventory";
 import {
   buildTelegramDmConfig,
@@ -55,6 +67,9 @@ type CatalogModel = {
   id?: string;
   name?: string;
   contextWindow?: number;
+  api?: string;
+  baseUrl?: string;
+  apiKey?: string;
 };
 
 type CatalogRegistry = {
@@ -67,6 +82,11 @@ type CatalogRegistry = {
   };
   getProviderDisplayName: (provider: string) => string;
   refresh: () => void | Promise<void>;
+  getApiKeyForProvider?: (provider: string) => Promise<string | undefined>;
+  getApiKeyAndHeaders?: (model: CatalogModel) => Promise<{
+    ok?: boolean;
+    apiKey?: string;
+  }>;
 };
 
 const MODEL_REGISTRY_REFRESH_TIMEOUT_MS = 2_000;
@@ -128,10 +148,12 @@ type CredentialStoreLike = {
     fn: (current: unknown) => Promise<ApiKeyCredential | undefined>,
   ) => Promise<unknown>;
   delete?: (provider: string) => Promise<void>;
+  read?: (provider: string) => Promise<unknown>;
 };
 
 type RegistryInternals = {
   runtime?: { credentials?: CredentialStoreLike };
+  credentials?: CredentialStoreLike;
   authStorage?: {
     set?: (provider: string, value: ApiKeyCredential) => void | Promise<void>;
     remove?: (provider: string) => void | Promise<void>;
@@ -363,50 +385,208 @@ async function buildModelCatalog(registry: CatalogRegistry, preferences: ModelPr
   };
 }
 
+function protocolFromModelApi(api: unknown): ProviderProtocol | null {
+  const value = String(api || "").trim();
+  if (value === "anthropic-messages") return "anthropic-messages";
+  if (
+    value === "openai-completions" ||
+    value === "openai-responses" ||
+    value === "azure-openai-responses" ||
+    value === "mistral-conversations"
+  ) {
+    return "openai-completions";
+  }
+  return null;
+}
+
+function credentialKey(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const cred = value as { type?: string; key?: unknown; access?: unknown };
+  if (cred.type === "api_key" && typeof cred.key === "string" && cred.key.trim()) {
+    return cred.key.trim();
+  }
+  if (cred.type === "oauth" && typeof cred.access === "string" && cred.access.trim()) {
+    return cred.access.trim();
+  }
+  return undefined;
+}
+
+async function resolveProviderApiKeyForHealthCheck(
+  registry: CatalogRegistry,
+  provider: string,
+  model: CatalogModel,
+): Promise<string | undefined> {
+  if (typeof registry.getApiKeyForProvider === "function") {
+    try {
+      const key = await registry.getApiKeyForProvider(provider);
+      if (typeof key === "string" && key.trim()) return key.trim();
+    } catch {
+      // fall through
+    }
+  }
+  if (typeof registry.getApiKeyAndHeaders === "function") {
+    try {
+      const auth = await registry.getApiKeyAndHeaders(model);
+      if (auth?.ok !== false && typeof auth?.apiKey === "string" && auth.apiKey.trim()) {
+        return auth.apiKey.trim();
+      }
+    } catch {
+      // fall through
+    }
+  }
+  const internals = registry as CatalogRegistry & RegistryInternals;
+  const store = internals.runtime?.credentials ?? internals.credentials;
+  if (typeof store?.read === "function") {
+    try {
+      const key = credentialKey(await store.read(provider));
+      if (key) return key;
+    } catch {
+      // fall through
+    }
+  }
+  if (typeof model.apiKey === "string" && model.apiKey.trim()) return model.apiKey.trim();
+  try {
+    const key = credentialKey(readAuthConfig()[provider]);
+    if (key) return key;
+  } catch {
+    // ignore
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(MODELS_CONFIG_PATH, "utf8")) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    const key = parsed.providers?.[provider]?.apiKey;
+    if (typeof key === "string" && key.trim()) return key.trim();
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+function asProviderProtocol(value: unknown): ProviderProtocol {
+  if (value === "openai-completions" || value === "anthropic-messages") return value;
+  throw new Error("protocol must be openai-completions or anthropic-messages");
+}
+
+function parseProbeModels(params: Record<string, unknown>): ProbeModel[] {
+  const modelsRaw = params.models;
+  if (Array.isArray(modelsRaw)) {
+    return modelsRaw
+      .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object")
+      .map((item) => ({
+        id: typeof item.id === "string" ? item.id.trim() : "",
+        ...(typeof item.name === "string" ? { name: item.name } : {}),
+        ...(typeof item.contextWindow === "number" ? { contextWindow: item.contextWindow } : {}),
+        ...(typeof item.maxTokens === "number" ? { maxTokens: item.maxTokens } : {}),
+      }))
+      .filter((model) => Boolean(model.id));
+  }
+  const modelIds = params.modelIds;
+  if (!Array.isArray(modelIds)) return [];
+  return modelIds
+    .map((id) => (typeof id === "string" ? id.trim() : ""))
+    .filter(Boolean)
+    .map((id) => ({ id }));
+}
+
+async function runHttpModelHealthCheck(
+  registry: CatalogRegistry,
+  model: CatalogModel,
+): Promise<{ ok: boolean; latencyMs: number; error?: string } | null> {
+  const protocol = protocolFromModelApi(model.api);
+  const baseUrl = typeof model.baseUrl === "string" ? model.baseUrl.trim() : "";
+  const provider = typeof model.provider === "string" ? model.provider : "";
+  const modelId = typeof model.id === "string" ? model.id : "";
+  if (!protocol || !baseUrl || !provider || !modelId) return null;
+  const apiKey = await resolveProviderApiKeyForHealthCheck(registry, provider, model);
+  if (!apiKey) return null;
+  const probe = await testProviderConnectivity({
+    baseUrl,
+    apiKey,
+    protocol,
+    modelId,
+  });
+  return {
+    ok: probe.ok,
+    latencyMs: probe.latencyMs,
+    error: probe.ok
+      ? undefined
+      : probe.error || (probe.status ? `HTTP ${probe.status}` : "Health check failed"),
+  };
+}
+
+async function runSessionModelHealthCheck(model: CatalogModel): Promise<{
+  ok: boolean;
+  error?: string;
+}> {
+  let sawAssistantText = false;
+  const modelRuntime = await ModelRuntime.create();
+  const { session } = await createAgentSession({
+    model,
+    tools: [],
+    sessionManager: SessionManager.inMemory(),
+    modelRuntime,
+  } as Parameters<typeof createAgentSession>[0]);
+  try {
+    const unsubscribe = session.subscribe((event: unknown) => {
+      const evt = event as {
+        assistantMessageEvent?: { type?: string; delta?: string };
+        message?: { content?: unknown };
+      };
+      if (
+        evt.assistantMessageEvent?.type === "text_delta" &&
+        typeof evt.assistantMessageEvent.delta === "string" &&
+        evt.assistantMessageEvent.delta.length > 0
+      ) {
+        sawAssistantText = true;
+      }
+      const content = evt.message?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (
+            block &&
+            typeof block === "object" &&
+            (block as { type?: string }).type === "text" &&
+            typeof (block as { text?: unknown }).text === "string" &&
+            (block as { text: string }).text.trim()
+          ) {
+            sawAssistantText = true;
+          }
+        }
+      }
+    });
+    try {
+      await session.prompt("Reply exactly: OK");
+    } finally {
+      unsubscribe();
+    }
+  } finally {
+    session.dispose();
+  }
+  return {
+    ok: sawAssistantText,
+    error: sawAssistantText ? undefined : "No assistant text returned",
+  };
+}
+
 async function runModelHealthCheck(
-  _registry: CatalogRegistry,
+  registry: CatalogRegistry,
   model: CatalogModel,
   preferences: ModelPreferencesStore,
 ): Promise<{ provider: string; modelId: string } & ModelHealth> {
   const provider = model.provider as string;
   const modelId = model.id as string;
   const startedAt = Date.now();
-  let sawAssistantText = false;
   try {
-    const modelRuntime = await ModelRuntime.create();
-    const { session } = await createAgentSession({
-      model,
-      thinkingLevel: "off",
-      tools: [],
-      sessionManager: SessionManager.inMemory(),
-      modelRuntime,
-    } as Parameters<typeof createAgentSession>[0]);
-    try {
-      const unsubscribe = session.subscribe((event: unknown) => {
-        const evt = event as { assistantMessageEvent?: { type?: string; delta?: string } };
-        if (
-          evt.assistantMessageEvent?.type === "text_delta" &&
-          typeof evt.assistantMessageEvent.delta === "string" &&
-          evt.assistantMessageEvent.delta.length > 0
-        ) {
-          sawAssistantText = true;
-        }
-      });
-      try {
-        await session.prompt("Reply exactly: OK");
-      } finally {
-        unsubscribe();
-      }
-    } finally {
-      session.dispose();
-    }
+    const httpProbe = await runHttpModelHealthCheck(registry, model);
+    const probe = httpProbe ?? (await runSessionModelHealthCheck(model));
     const result: { provider: string; modelId: string } & ModelHealth = {
       provider,
       modelId,
-      status: sawAssistantText ? "healthy" : "unhealthy",
+      status: probe.ok ? "healthy" : "unhealthy",
       checkedAt: new Date().toISOString(),
-      latencyMs: Date.now() - startedAt,
-      error: sawAssistantText ? undefined : "No assistant text returned",
+      latencyMs: httpProbe?.latencyMs ?? Date.now() - startedAt,
+      error: probe.ok ? undefined : sanitizeHealthError(probe.error || "Health check failed"),
     };
     preferences.setHealth(provider, modelId, result);
     return result;
@@ -885,6 +1065,90 @@ export async function handlePicotConfig(
         writeConfigFile(MODELS_CONFIG_PATH, content);
         const refreshed = await refreshRegistryBestEffort(registry);
         return { ok: true, data: { path: MODELS_CONFIG_PATH, refreshed } };
+      }
+
+      case "detect_custom_provider": {
+        const preferredRaw = asString(params.preferred) || "auto";
+        const preferred =
+          preferredRaw === "openai-completions" || preferredRaw === "anthropic-messages"
+            ? preferredRaw
+            : "auto";
+        const result = await detectProviderProtocol({
+          baseUrl: asString(params.baseUrl),
+          apiKey: asString(params.apiKey),
+          preferred,
+        });
+        return { ok: true, data: result };
+      }
+
+      case "list_custom_provider_models": {
+        const listed = await fetchUpstreamModels({
+          baseUrl: asString(params.baseUrl),
+          apiKey: asString(params.apiKey),
+          protocol: asProviderProtocol(params.protocol),
+        });
+        return { ok: true, data: listed };
+      }
+
+      case "test_custom_provider": {
+        const result = await testProviderConnectivity({
+          baseUrl: asString(params.baseUrl),
+          apiKey: asString(params.apiKey),
+          protocol: asProviderProtocol(params.protocol),
+          modelId: asString(params.modelId) || undefined,
+        });
+        return { ok: true, data: result };
+      }
+
+      case "save_custom_provider": {
+        const protocol = asProviderProtocol(params.protocol);
+        const baseUrl = normalizeBaseUrl(asString(params.baseUrl));
+        const providerId = resolveProviderId(asString(params.providerId), baseUrl);
+        const models = parseProbeModels(params);
+        if (models.length === 0) throw new Error("Select at least one model");
+        const apiKey = asString(params.apiKey);
+        const storeKey = params.storeKey !== false;
+        const includeApiKeyInFile = params.includeApiKeyInFile === true;
+        if (storeKey && !apiKey) throw new Error("apiKey is required when storeKey is true");
+        const entry = buildModelsJsonProviderEntry({
+          baseUrl,
+          protocol,
+          models,
+          apiKey,
+          includeApiKeyInFile,
+        });
+        let existing: unknown = { providers: {} };
+        if (fs.existsSync(MODELS_CONFIG_PATH)) {
+          try {
+            existing = JSON.parse(fs.readFileSync(MODELS_CONFIG_PATH, "utf8"));
+          } catch {
+            existing = { providers: {} };
+          }
+        }
+        const merged = mergeProviderIntoModelsJson(
+          existing as ModelsJsonDocument,
+          providerId,
+          entry,
+        );
+        writeConfigFile(MODELS_CONFIG_PATH, `${JSON.stringify(merged, null, 2)}\n`);
+        let keyStored = false;
+        if (storeKey && apiKey) {
+          await setStoredApiKey(registry, providerId, apiKey);
+          keyStored = true;
+        }
+        const refreshed = await refreshRegistryBestEffort(registry);
+        return {
+          ok: true,
+          data: {
+            providerId,
+            baseUrl,
+            protocol,
+            modelCount: models.length,
+            keyStored,
+            refreshed,
+            path: MODELS_CONFIG_PATH,
+          },
+        };
       }
 
       case "read_chat_config":

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -157,7 +157,8 @@
     "processStep": "{count} step",
     "processSteps": "{count} steps",
     "processToolCall": "{count} tool call",
-    "processToolCalls": "{count} tool calls"
+    "processToolCalls": "{count} tool calls",
+    "providerError": "The model request failed."
   },
   "tools": {
     "copyOutput": "Copy output",
@@ -664,6 +665,48 @@
       "helpPost2": "for the full schema. Changes are picked up immediately — no restart needed.",
       "replaceConfirm": "Replace current content with the Ollama example?",
       "docsOpenFailed": "Could not open the documentation link"
+    },
+    "providerPicker": {
+      "builtIn": "Built-in",
+      "subscriptions": "Subscriptions",
+      "custom": "Custom",
+      "oauth": "OAuth",
+      "customEndpoint": "Custom endpoint format",
+      "modelCount": "{count} models"
+    },
+    "customProvider": {
+      "title": "Add custom provider",
+      "subtitle": "Detect an OpenAI-compatible or Anthropic relay, pick models, then save.",
+      "id": "Provider ID (optional)",
+      "idPlaceholder": "Leave blank to derive from the Base URL",
+      "baseUrl": "Base URL",
+      "apiKey": "API key",
+      "apiKeyPlaceholder": "Required for detect / test / save",
+      "protocol": "Protocol",
+      "protocolAuto": "Auto-detect",
+      "protocolOpenAi": "OpenAI compatible",
+      "protocolAnthropic": "Claude / Anthropic",
+      "models": "Upstream models",
+      "selectAll": "Select all",
+      "deselectAll": "Deselect all",
+      "detect": "Detect",
+      "test": "Test connectivity",
+      "save": "Save provider",
+      "baseUrlRequired": "Base URL is required.",
+      "keyRequired": "API key is required.",
+      "detectFirst": "Detect the protocol first, or choose it manually.",
+      "modelsRequired": "Select at least one model.",
+      "detecting": "Detecting protocol…",
+      "testing": "Testing connectivity…",
+      "saving": "Saving provider…",
+      "detected": "Detected {protocol} · {count} models",
+      "detectFailed": "Could not detect the protocol.",
+      "testOk": "Reachable · {ms}ms",
+      "testFailed": "Connectivity test failed.",
+      "saved": "Saved {id} with {count} models",
+      "saveFailed": "Failed to save provider.",
+      "keyStored": " · API key stored",
+      "keyNotStored": " · API key was not stored"
     },
     "apiKeys": {
       "noProviders": "No providers known.",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -157,7 +157,8 @@
     "processStep": "{count} paso",
     "processSteps": "{count} pasos",
     "processToolCall": "{count} llamada a herramienta",
-    "processToolCalls": "{count} llamadas a herramientas"
+    "processToolCalls": "{count} llamadas a herramientas",
+    "providerError": "La solicitud al modelo falló."
   },
   "tools": {
     "copyOutput": "Copiar salida",
@@ -664,6 +665,48 @@
       "helpPost2": "para el esquema completo. Los cambios se aplican inmediatamente — no se requiere reinicio.",
       "replaceConfirm": "¿Reemplazar el contenido actual con el ejemplo de Ollama?",
       "docsOpenFailed": "No se pudo abrir el enlace de documentación"
+    },
+    "providerPicker": {
+      "builtIn": "Integrados",
+      "subscriptions": "Suscripciones",
+      "custom": "Personalizado",
+      "oauth": "OAuth",
+      "customEndpoint": "Formato de endpoint personalizado",
+      "modelCount": "{count} modelos"
+    },
+    "customProvider": {
+      "title": "Añadir proveedor personalizado",
+      "subtitle": "Detecta un relay compatible con OpenAI o Anthropic, elige modelos y guarda.",
+      "id": "ID del proveedor (opcional)",
+      "idPlaceholder": "Déjalo vacío para derivarlo de la Base URL",
+      "baseUrl": "Base URL",
+      "apiKey": "Clave API",
+      "apiKeyPlaceholder": "Obligatoria para detectar / probar / guardar",
+      "protocol": "Protocolo",
+      "protocolAuto": "Detección automática",
+      "protocolOpenAi": "Compatible con OpenAI",
+      "protocolAnthropic": "Claude / Anthropic",
+      "models": "Modelos upstream",
+      "selectAll": "Seleccionar todos",
+      "deselectAll": "Deseleccionar todos",
+      "detect": "Detectar",
+      "test": "Probar conectividad",
+      "save": "Guardar proveedor",
+      "baseUrlRequired": "La Base URL es obligatoria.",
+      "keyRequired": "La clave API es obligatoria.",
+      "detectFirst": "Detecta el protocolo primero, o elígelo manualmente.",
+      "modelsRequired": "Selecciona al menos un modelo.",
+      "detecting": "Detectando protocolo…",
+      "testing": "Probando conectividad…",
+      "saving": "Guardando proveedor…",
+      "detected": "Detectado {protocol} · {count} modelos",
+      "detectFailed": "No se pudo detectar el protocolo.",
+      "testOk": "Alcanzable · {ms}ms",
+      "testFailed": "Falló la prueba de conectividad.",
+      "saved": "Guardado {id} con {count} modelos",
+      "saveFailed": "No se pudo guardar el proveedor.",
+      "keyStored": " · clave API almacenada",
+      "keyNotStored": " · la clave API no se almacenó"
     },
     "apiKeys": {
       "noProviders": "No hay proveedores conocidos.",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -157,7 +157,8 @@
     "processStep": "{count} ステップ",
     "processSteps": "{count} ステップ",
     "processToolCall": "{count} 件のツール呼び出し",
-    "processToolCalls": "{count} 件のツール呼び出し"
+    "processToolCalls": "{count} 件のツール呼び出し",
+    "providerError": "モデルへのリクエストに失敗しました。"
   },
   "tools": {
     "copyOutput": "出力をコピー",
@@ -664,6 +665,48 @@
       "helpPost2": "を参照してください。変更はすぐに反映されます — 再起動不要。",
       "replaceConfirm": "現在の内容をOllamaの例で置き換えますか？",
       "docsOpenFailed": "ドキュメントリンクを開けませんでした"
+    },
+    "providerPicker": {
+      "builtIn": "組み込み",
+      "subscriptions": "サブスクリプション",
+      "custom": "カスタム",
+      "oauth": "OAuth",
+      "customEndpoint": "カスタムエンドポイント",
+      "modelCount": "{count}モデル"
+    },
+    "customProvider": {
+      "title": "カスタムプロバイダーを追加",
+      "subtitle": "OpenAI互換またはAnthropic中継を検出し、モデルを選んで保存します。",
+      "id": "プロバイダー ID（任意）",
+      "idPlaceholder": "空欄なら Base URL から自動生成",
+      "baseUrl": "Base URL",
+      "apiKey": "APIキー",
+      "apiKeyPlaceholder": "検出 / テスト / 保存に必要",
+      "protocol": "プロトコル",
+      "protocolAuto": "自動検出",
+      "protocolOpenAi": "OpenAI互換",
+      "protocolAnthropic": "Claude / Anthropic",
+      "models": "上流モデル",
+      "selectAll": "すべて選択",
+      "deselectAll": "すべて解除",
+      "detect": "検出",
+      "test": "接続テスト",
+      "save": "プロバイダーを保存",
+      "baseUrlRequired": "Base URL は必須です。",
+      "keyRequired": "APIキーは必須です。",
+      "detectFirst": "先にプロトコルを検出するか、手動で選択してください。",
+      "modelsRequired": "少なくとも1つのモデルを選択してください。",
+      "detecting": "プロトコルを検出しています…",
+      "testing": "接続をテストしています…",
+      "saving": "プロバイダーを保存しています…",
+      "detected": "{protocol} を検出 · {count} モデル",
+      "detectFailed": "プロトコルを検出できませんでした。",
+      "testOk": "到達可能 · {ms}ms",
+      "testFailed": "接続テストに失敗しました。",
+      "saved": "{id} を {count} モデルで保存しました",
+      "saveFailed": "プロバイダーの保存に失敗しました。",
+      "keyStored": " · APIキーを保存しました",
+      "keyNotStored": " · APIキーは保存されませんでした"
     },
     "apiKeys": {
       "noProviders": "既知のプロバイダーがありません。",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -157,7 +157,8 @@
     "processStep": "{count} 个步骤",
     "processSteps": "{count} 个步骤",
     "processToolCall": "{count} 次工具调用",
-    "processToolCalls": "{count} 次工具调用"
+    "processToolCalls": "{count} 次工具调用",
+    "providerError": "模型请求失败。"
   },
   "tools": {
     "copyOutput": "复制输出",
@@ -664,6 +665,48 @@
       "helpPost2": "了解完整架构。更改即时生效 — 无需重启。",
       "replaceConfirm": "用 Ollama 示例替换当前内容？",
       "docsOpenFailed": "无法打开文档链接"
+    },
+    "providerPicker": {
+      "builtIn": "内置",
+      "subscriptions": "订阅",
+      "custom": "自定义",
+      "oauth": "OAuth",
+      "customEndpoint": "自定义接口格式",
+      "modelCount": "{count} 个模型"
+    },
+    "customProvider": {
+      "title": "添加自定义供应商",
+      "subtitle": "识别 OpenAI 兼容或 Anthropic 中转，勾选模型后保存。",
+      "id": "供应商 ID（可选）",
+      "idPlaceholder": "留空则根据 Base URL 自动生成",
+      "baseUrl": "Base URL",
+      "apiKey": "API 密钥",
+      "apiKeyPlaceholder": "识别 / 测试 / 保存时必填",
+      "protocol": "协议",
+      "protocolAuto": "自动识别",
+      "protocolOpenAi": "OpenAI 兼容",
+      "protocolAnthropic": "Claude / Anthropic",
+      "models": "上游模型",
+      "selectAll": "全选",
+      "deselectAll": "取消全选",
+      "detect": "识别",
+      "test": "测试连通性",
+      "save": "保存供应商",
+      "baseUrlRequired": "请填写 Base URL。",
+      "keyRequired": "请填写 API 密钥。",
+      "detectFirst": "请先识别协议，或手动选择协议。",
+      "modelsRequired": "请至少选择一个模型。",
+      "detecting": "正在识别协议…",
+      "testing": "正在测试连通性…",
+      "saving": "正在保存供应商…",
+      "detected": "已识别 {protocol} · {count} 个模型",
+      "detectFailed": "无法识别协议。",
+      "testOk": "可达 · {ms}ms",
+      "testFailed": "连通性测试失败。",
+      "saved": "已保存 {id}（{count} 个模型）",
+      "saveFailed": "保存供应商失败。",
+      "keyStored": " · 密钥已写入",
+      "keyNotStored": " · 密钥未写入"
     },
     "apiKeys": {
       "noProviders": "无已知提供者。",

--- a/public/native/app.js
+++ b/public/native/app.js
@@ -53,6 +53,7 @@ import {
   createNativeTaskNotificationSender,
   createTaskCompletionNotifications,
 } from "./notifications/task-completion-notifications.js";
+import { extractAssistantError, extractRuntimeEventError } from "./session/assistant-error.js";
 import { setupSessionInfo } from "./session/session-info.js";
 import { createSessionSelectionHandler } from "./session/session-navigation.js";
 import { setupSessionSearchDialog } from "./session/session-search-dialog.js";
@@ -247,6 +248,7 @@ let navigationGeneration = 0;
 let commandCatalog = buildCommandCatalog({});
 let streamingElement = null;
 let liveProcessGroup = null;
+let lastShownProviderError = null;
 let sidebar = null;
 let agentInboxNavSelectSession = null;
 // Sidebar loading starts before bootstrap/runtime awaits complete. Keep every
@@ -1679,16 +1681,14 @@ function runBuiltin(action) {
 async function handleRuntimeEvent(event) {
   switch (event.type) {
     case "agent_start":
+      lastShownProviderError = null;
       setStatus("working");
       contextUsage.setWorking(true);
       sidebar?.setStreaming(target.sessionId, true);
       break;
     case "agent_settled":
-      setStatus("connected");
-      contextUsage.setWorking(false);
-      sidebar?.setStreaming(target.sessionId, false);
-      hideLiveProcessIndicator();
-      collapseCompletedTurn({ markDone: true });
+    case "agent_end":
+      settleForegroundAgent(event);
       break;
     case "session_info_changed":
       sidebar?.setSessionName(target.sessionId, event.name);
@@ -1732,14 +1732,17 @@ async function handleRuntimeEvent(event) {
       }
       break;
     case "message_end":
-      if (event.message?.role === "assistant" && streamingElement) {
-        messageRenderer.updateStreamingMessage(streamingElement, event.message.content ?? []);
-        messageRenderer.finalizeStreamingMessage(streamingElement, event.message.usage ?? null);
-        contextUsage.setUsage(event.message.usage ?? null, currentModelContextWindow);
-        setSessionCost(sessionTotalCost + (event.message.usage?.cost?.total ?? 0));
-        headerStatusBar?.applyLiveUsage?.(event.message.usage ?? null);
-        streamingElement = null;
-        convNav.notifyNewMessage();
+      if (event.message?.role === "assistant") {
+        if (streamingElement) {
+          messageRenderer.updateStreamingMessage(streamingElement, event.message.content ?? []);
+          messageRenderer.finalizeStreamingMessage(streamingElement, event.message.usage ?? null);
+          contextUsage.setUsage(event.message.usage ?? null, currentModelContextWindow);
+          setSessionCost(sessionTotalCost + (event.message.usage?.cost?.total ?? 0));
+          headerStatusBar?.applyLiveUsage?.(event.message.usage ?? null);
+          streamingElement = null;
+          convNav.notifyNewMessage();
+        }
+        showProviderErrorIfNeeded(event);
       }
       break;
     case "tool_execution_start":
@@ -1854,6 +1857,15 @@ async function adoptTarget(nextTarget, { updateRoute = true } = {}) {
   input.value = draft || "";
   composerAutoResize.sync();
   await extensionUi.setForegroundSession(target.sessionId, { flush: false });
+}
+
+function lastAssistantErrorInRange(messages, start, end) {
+  for (let i = end - 1; i >= start; i -= 1) {
+    if (messages[i]?.role === "assistant") {
+      return extractAssistantError(messages[i], { fallback: t("messages.providerError") });
+    }
+  }
+  return null;
 }
 
 /** Non-empty rendered text for an assistant message's `text` blocks. */
@@ -2042,6 +2054,9 @@ function renderHistory(messages) {
       }
     }
 
+    const turnError = lastAssistantErrorInRange(messages, bodyStart, end);
+    if (turnError) messageRenderer.renderError(turnError);
+
     if (group) {
       if (group.body.children.length > 0) {
         group.setLabel(summarizeProcessGroup(stepCount, toolCallCount));
@@ -2176,6 +2191,22 @@ function abortCurrentRun() {
   // that only the UI can send. Without this, an unanswered/cancelled prompt
   // leaves the run wedged forever with Stop appearing to do nothing.
   extensionUi.cancelForeground();
+}
+
+function settleForegroundAgent(event) {
+  setStatus("connected");
+  contextUsage.setWorking(false);
+  sidebar?.setStreaming(target.sessionId, false);
+  hideLiveProcessIndicator();
+  collapseCompletedTurn({ markDone: true });
+  showProviderErrorIfNeeded(event);
+}
+
+function showProviderErrorIfNeeded(event) {
+  const error = extractRuntimeEventError(event, { fallback: t("messages.providerError") });
+  if (!error || error === lastShownProviderError) return;
+  lastShownProviderError = error;
+  messageRenderer.renderError(error);
 }
 
 function showError(error) {

--- a/public/native/session/assistant-error.js
+++ b/public/native/session/assistant-error.js
@@ -1,0 +1,46 @@
+/**
+ * Extract provider/LLM failure text from Pi runtime events.
+ *
+ * A failed Groq/OpenAI call typically arrives as:
+ *   { type: "message_end", message: { role: "assistant", stopReason: "error", errorMessage, content: [] } }
+ * The transcript has no assistant text, so the UI must read errorMessage itself.
+ */
+
+function trimmedString(value) {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (
+    value &&
+    typeof value === "object" &&
+    typeof value.message === "string" &&
+    value.message.trim()
+  ) {
+    return value.message.trim();
+  }
+  return "";
+}
+
+export function extractAssistantError(message, { fallback } = {}) {
+  if (!message || (message.role && message.role !== "assistant")) return null;
+  const stop = typeof message.stopReason === "string" ? message.stopReason : "";
+  if (stop === "aborted") return null;
+  const text = trimmedString(message.errorMessage) || trimmedString(message.error);
+  if (text) return text;
+  if (stop === "error") return fallback || "The model request failed.";
+  return null;
+}
+
+export function extractRuntimeEventError(event, { fallback } = {}) {
+  if (!event || typeof event !== "object") return null;
+  if (event.type === "message_end") {
+    return extractAssistantError(event.message, { fallback });
+  }
+  if (event.type !== "agent_end" && event.type !== "agent_settled") return null;
+  const direct = trimmedString(event.errorMessage) || trimmedString(event.error);
+  if (direct) return direct;
+  const messages = Array.isArray(event.messages) ? event.messages : [];
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const err = extractAssistantError(messages[i], { fallback });
+    if (err) return err;
+  }
+  return extractAssistantError(event.message, { fallback });
+}

--- a/public/native/session/assistant-error.test.js
+++ b/public/native/session/assistant-error.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+import { extractAssistantError, extractRuntimeEventError } from "./assistant-error.js";
+
+describe("extractAssistantError", () => {
+  test("reads errorMessage from an empty failed assistant message", () => {
+    expect(
+      extractAssistantError({
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "Unknown parameter: 'store'",
+        content: [],
+      }),
+    ).toBe("Unknown parameter: 'store'");
+  });
+
+  test("ignores aborted turns", () => {
+    expect(
+      extractAssistantError({
+        role: "assistant",
+        stopReason: "aborted",
+        errorMessage: "Request was aborted",
+      }),
+    ).toBeNull();
+  });
+
+  test("falls back when stopReason is error but no text", () => {
+    expect(
+      extractAssistantError(
+        { role: "assistant", stopReason: "error", content: [] },
+        { fallback: "failed" },
+      ),
+    ).toBe("failed");
+  });
+});
+
+describe("extractRuntimeEventError", () => {
+  test("reads message_end errors", () => {
+    expect(
+      extractRuntimeEventError({
+        type: "message_end",
+        message: { role: "assistant", stopReason: "error", errorMessage: "HTTP 400" },
+      }),
+    ).toBe("HTTP 400");
+  });
+
+  test("reads the last failed assistant on agent_end", () => {
+    expect(
+      extractRuntimeEventError({
+        type: "agent_end",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "hi" }] },
+          { role: "assistant", stopReason: "error", errorMessage: "Connection error." },
+        ],
+      }),
+    ).toBe("Connection error.");
+  });
+
+  test("returns null on a successful settle", () => {
+    expect(
+      extractRuntimeEventError({
+        type: "agent_settled",
+        messages: [
+          { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "ok" }] },
+        ],
+      }),
+    ).toBeNull();
+  });
+});

--- a/public/native/settings/settings-config.css
+++ b/public/native/settings/settings-config.css
@@ -109,14 +109,15 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
   padding: var(--space-2) var(--space-1-5);
   background: var(--bg-glass-strong, var(--bg-glass));
   border-right: 1px solid var(--border);
 }
 
 .models-provider-list {
-  flex: 1;
-  overflow-y: auto;
+  flex: 0 0 auto;
 }
 
 .models-provider-item,
@@ -186,6 +187,7 @@
 }
 
 .models-provider-add {
+  flex-shrink: 0;
   justify-content: center;
   padding: var(--space-2);
   margin-top: var(--space-2);
@@ -513,8 +515,49 @@
 .provider-setup-actions {
   display: flex;
   justify-content: flex-end;
+  flex-wrap: wrap;
   gap: var(--space-2);
   margin-top: var(--space-5);
+}
+.custom-provider-models {
+  display: grid;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+.custom-provider-models.hidden,
+.custom-provider-status.hidden {
+  display: none;
+}
+.custom-provider-models-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+.custom-provider-models-list {
+  display: grid;
+  gap: var(--space-1);
+  max-height: 220px;
+  overflow: auto;
+}
+.custom-provider-model-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
+}
+.custom-provider-status {
+  margin-top: var(--space-3);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+.custom-provider-status.is-ok {
+  color: var(--success);
+}
+.custom-provider-status.is-error {
+  color: var(--error);
 }
 .provider-picker-card {
   display: flex;

--- a/public/native/settings/settings-config.js
+++ b/public/native/settings/settings-config.js
@@ -12,6 +12,7 @@ import {
   createLoadingPlaceholder,
 } from "../../ui/loading-placeholder.js";
 import { enhanceSelect } from "../../ui/select-menu.js";
+import { openCustomProviderEditor } from "./settings-custom-provider.js";
 import {
   clearSettingsSaveMessage,
   setSettingsSaveButtonSaving,
@@ -199,35 +200,40 @@ export function setupSettingsConfig({ configGateway, onModelConfigurationChanged
         custom: true,
       };
       const groups = [
-        [
-          "Custom",
-          !q || "custom openai-compatible anthropic-compatible".includes(q)
-            ? [custom]
-            : matches.filter((p) => p.custom || p.provider === "custom"),
-        ],
-        [
-          "Subscriptions",
-          matches.filter(
-            (p) =>
-              !p.custom &&
-              (p.authType === "oauth" || p.source === "oauth" || p.source === "subscription"),
-          ),
-        ],
-        [
-          "API key",
-          matches.filter(
+        {
+          id: "builtIn",
+          label: t("settings.providerPicker.builtIn"),
+          items: matches.filter(
             (p) =>
               !p.custom &&
               p.authType !== "oauth" &&
               p.source !== "oauth" &&
               p.source !== "subscription",
           ),
-        ],
+        },
+        {
+          id: "subscriptions",
+          label: t("settings.providerPicker.subscriptions"),
+          items: matches.filter(
+            (p) =>
+              !p.custom &&
+              (p.authType === "oauth" || p.source === "oauth" || p.source === "subscription"),
+          ),
+        },
+        {
+          id: "custom",
+          label: t("settings.providerPicker.custom"),
+          items:
+            !q || "custom openai-compatible anthropic-compatible".includes(q)
+              ? [custom]
+              : matches.filter((p) => p.custom || p.provider === "custom"),
+        },
       ];
-      for (const [label, items] of groups) {
+      for (const { id, label, items } of groups) {
         if (!items.length) continue;
         const heading = document.createElement("div");
         heading.className = "provider-picker-section-title";
+        heading.dataset.section = id;
         heading.textContent = label;
         grid.appendChild(heading);
         for (const p of items) {
@@ -240,20 +246,32 @@ export function setupSettingsConfig({ configGateway, onModelConfigurationChanged
           strong.textContent = p.displayName || p.provider;
           const small = document.createElement("small");
           small.textContent =
-            label === "Subscriptions"
-              ? "OAuth"
-              : label === "Custom"
-                ? "Custom endpoint format"
-                : `${Array.isArray(p.models) ? p.models.length : 0} models`;
+            id === "subscriptions"
+              ? t("settings.providerPicker.oauth")
+              : id === "custom"
+                ? t("settings.providerPicker.customEndpoint")
+                : t("settings.providerPicker.modelCount", {
+                    count: Array.isArray(p.models) ? p.models.length : 0,
+                  });
           text.append(strong, small);
           card.append(logo, text);
           card.addEventListener("click", () => {
             backdrop.remove();
             if (p.custom) {
-              openCustomProviderEditor();
+              openCustomProviderEditor({
+                call,
+                setupDialog,
+                onSaved: async (providerId) => {
+                  if (providerId) {
+                    selectedModelsConfigItem = { type: "provider", provider: providerId };
+                  }
+                  await loadInlineModelsEditor();
+                  await loadApiKeysPanel();
+                },
+              });
               return;
             }
-            if (label === "Subscriptions") {
+            if (id === "subscriptions") {
               openSubscriptionSetup(p);
               return;
             }
@@ -332,80 +350,6 @@ export function setupSettingsConfig({ configGateway, onModelConfigurationChanged
     close.onclick = () => backdrop.remove();
     actions.appendChild(close);
     dialog.appendChild(actions);
-  }
-
-  function openCustomProviderEditor() {
-    const { backdrop, dialog } = setupDialog(
-      "Add custom provider",
-      "Connect an OpenAI-compatible or Anthropic-compatible endpoint.",
-    );
-    const form = document.createElement("div");
-    form.className = "provider-setup-form";
-    const fields = [
-      ["Provider ID", "provider", "my-provider"],
-      ["Base URL", "baseUrl", "https://api.example.com/v1"],
-      ["API key", "apiKey", "Optional"],
-      ["Model ID", "modelId", "model-name"],
-    ];
-    const inputs = {};
-    for (const [label, key, placeholder] of fields) {
-      const wrap = document.createElement("label");
-      wrap.textContent = label;
-      const input = document.createElement("input");
-      input.className = "ui-input";
-      input.placeholder = placeholder;
-      input.type = key === "apiKey" ? "password" : "text";
-      wrap.appendChild(input);
-      form.appendChild(wrap);
-      inputs[key] = input;
-    }
-    dialog.appendChild(form);
-    const error = document.createElement("div");
-    error.className = "api-key-editor-error";
-    dialog.appendChild(error);
-    const actions = document.createElement("div");
-    actions.className = "provider-setup-actions";
-    const cancel = document.createElement("button");
-    cancel.className = "ui-button ui-button--secondary";
-    cancel.textContent = "Cancel";
-    cancel.onclick = () => backdrop.remove();
-    const save = document.createElement("button");
-    save.className = "ui-button ui-button--primary";
-    save.textContent = "Save provider";
-    actions.append(cancel, save);
-    dialog.appendChild(actions);
-    save.onclick = async () => {
-      const id = inputs.provider.value.trim(),
-        baseUrl = inputs.baseUrl.value.trim(),
-        modelId = inputs.modelId.value.trim();
-      if (!id || !baseUrl || !modelId) {
-        error.textContent = "Provider ID, Base URL and Model ID are required.";
-        return;
-      }
-      save.disabled = true;
-      try {
-        const current = await call("read_models_config");
-        const json = JSON.parse(current.data.content || "{}");
-        json.providers ||= {};
-        json.providers[id] = {
-          baseUrl,
-          api: "openai-completions",
-          ...(inputs.apiKey.value.trim() ? { apiKey: inputs.apiKey.value.trim() } : {}),
-          models: [{ id: modelId }],
-        };
-        const result = await call("write_models_config", {
-          content: JSON.stringify(json, null, 2),
-        });
-        if (!result?.ok) throw new Error(result.error || "Failed to save provider");
-        backdrop.remove();
-        selectedModelsConfigItem = { type: "provider", provider: id };
-        await loadInlineModelsEditor();
-        await loadApiKeysPanel();
-      } catch (e) {
-        error.textContent = e.message;
-        save.disabled = false;
-      }
-    };
   }
 
   function escapeSelectorValue(value) {
@@ -957,7 +901,9 @@ export function setupSettingsConfig({ configGateway, onModelConfigurationChanged
       "apiKey": "ollama",
       "compat": {
         "supportsDeveloperRole": false,
-        "supportsReasoningEffort": false
+        "supportsReasoningEffort": false,
+        "supportsStore": false,
+        "supportsStrictMode": false
       },
       "models": [
         { "id": "llama3.1:8b" },

--- a/public/native/settings/settings-custom-provider.js
+++ b/public/native/settings/settings-custom-provider.js
@@ -1,0 +1,299 @@
+// Guided custom / relay provider form. Detects OpenAI-compatible vs
+// Anthropic protocols, lists upstream models, tests connectivity, then saves
+// into models.json via picot-config (CredentialStore for the API key).
+
+import { t } from "../../i18n.js";
+
+const PROBE_TIMEOUT_MS = 45_000;
+
+function createField(labelText, input) {
+  const wrap = document.createElement("label");
+  wrap.textContent = labelText;
+  wrap.appendChild(input);
+  return wrap;
+}
+
+function suggestProviderIdFromBaseUrl(baseUrl) {
+  try {
+    const host = new URL(baseUrl).hostname.replace(/^www\./, "");
+    const parts = host.split(".").filter(Boolean);
+    const slug = (parts.length >= 2 ? `${parts.at(-2)}-${parts.at(-1)}` : host)
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    return slug || "custom-relay";
+  } catch {
+    return "custom-relay";
+  }
+}
+
+export function openCustomProviderEditor({ call, setupDialog, onSaved }) {
+  const { backdrop, dialog } = setupDialog(
+    t("settings.customProvider.title"),
+    t("settings.customProvider.subtitle"),
+  );
+  const form = document.createElement("div");
+  form.className = "provider-setup-form";
+
+  const providerId = document.createElement("input");
+  providerId.className = "ui-input";
+  providerId.placeholder = t("settings.customProvider.idPlaceholder");
+  const baseUrl = document.createElement("input");
+  baseUrl.className = "ui-input";
+  baseUrl.placeholder = "https://api.example.com/v1";
+  const apiKey = document.createElement("input");
+  apiKey.className = "ui-input";
+  apiKey.type = "password";
+  apiKey.placeholder = t("settings.customProvider.apiKeyPlaceholder");
+  const protocol = document.createElement("select");
+  protocol.className = "ui-select";
+  for (const [value, label] of [
+    ["auto", t("settings.customProvider.protocolAuto")],
+    ["openai-completions", t("settings.customProvider.protocolOpenAi")],
+    ["anthropic-messages", t("settings.customProvider.protocolAnthropic")],
+  ]) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    protocol.appendChild(option);
+  }
+
+  form.append(
+    createField(t("settings.customProvider.id"), providerId),
+    createField(t("settings.customProvider.baseUrl"), baseUrl),
+    createField(t("settings.customProvider.apiKey"), apiKey),
+    createField(t("settings.customProvider.protocol"), protocol),
+  );
+  dialog.appendChild(form);
+
+  const modelsWrap = document.createElement("div");
+  modelsWrap.className = "custom-provider-models hidden";
+  const modelsHead = document.createElement("div");
+  modelsHead.className = "custom-provider-models-head";
+  const modelsTitle = document.createElement("span");
+  modelsTitle.textContent = t("settings.customProvider.models");
+  const selectAll = document.createElement("button");
+  selectAll.type = "button";
+  selectAll.className = "ui-button ui-button--ghost ui-button--sm";
+  selectAll.textContent = t("settings.customProvider.deselectAll");
+  modelsHead.append(modelsTitle, selectAll);
+  const modelsList = document.createElement("div");
+  modelsList.className = "custom-provider-models-list";
+  modelsWrap.append(modelsHead, modelsList);
+  dialog.appendChild(modelsWrap);
+
+  const status = document.createElement("div");
+  status.className = "custom-provider-status hidden";
+  status.setAttribute("role", "status");
+  dialog.appendChild(status);
+
+  const actions = document.createElement("div");
+  actions.className = "provider-setup-actions";
+  const cancel = document.createElement("button");
+  cancel.type = "button";
+  cancel.className = "ui-button ui-button--secondary";
+  cancel.textContent = t("actions.cancel");
+  cancel.onclick = () => backdrop.remove();
+  const detectBtn = document.createElement("button");
+  detectBtn.type = "button";
+  detectBtn.className = "ui-button ui-button--secondary";
+  detectBtn.textContent = t("settings.customProvider.detect");
+  const testBtn = document.createElement("button");
+  testBtn.type = "button";
+  testBtn.className = "ui-button ui-button--secondary";
+  testBtn.textContent = t("settings.customProvider.test");
+  const saveBtn = document.createElement("button");
+  saveBtn.type = "button";
+  saveBtn.className = "ui-button ui-button--primary";
+  saveBtn.textContent = t("settings.customProvider.save");
+  actions.append(cancel, detectBtn, testBtn, saveBtn);
+  dialog.appendChild(actions);
+
+  let detectedModels = [];
+  let detectedProtocol = null;
+
+  function setStatus(message, kind) {
+    if (!message) {
+      status.textContent = "";
+      status.classList.add("hidden");
+      status.classList.remove("is-error", "is-ok");
+      return;
+    }
+    status.textContent = message;
+    status.classList.remove("hidden", "is-error", "is-ok");
+    if (kind === "error") status.classList.add("is-error");
+    if (kind === "ok") status.classList.add("is-ok");
+  }
+
+  function renderModels(models) {
+    detectedModels = Array.isArray(models) ? models : [];
+    modelsList.replaceChildren();
+    if (detectedModels.length === 0) {
+      modelsWrap.classList.add("hidden");
+      return;
+    }
+    modelsWrap.classList.remove("hidden");
+    for (const model of detectedModels) {
+      const row = document.createElement("label");
+      row.className = "custom-provider-model-row";
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.className = "custom-provider-model-toggle";
+      checkbox.value = model.id;
+      checkbox.checked = true;
+      const label = document.createElement("span");
+      label.className = "custom-provider-model-id";
+      label.textContent = model.name ? `${model.id} · ${model.name}` : model.id;
+      row.append(checkbox, label);
+      modelsList.appendChild(row);
+    }
+    selectAll.textContent = t("settings.customProvider.deselectAll");
+  }
+
+  function selectedModels() {
+    const selectedIds = new Set(
+      [...modelsList.querySelectorAll(".custom-provider-model-toggle:checked")].map(
+        (el) => el.value,
+      ),
+    );
+    return detectedModels.filter((model) => selectedIds.has(model.id));
+  }
+
+  function resolvedProtocol() {
+    if (protocol.value !== "auto") return protocol.value;
+    return detectedProtocol;
+  }
+
+  selectAll.addEventListener("click", () => {
+    const toggles = [...modelsList.querySelectorAll(".custom-provider-model-toggle")];
+    const allChecked = toggles.length > 0 && toggles.every((toggle) => toggle.checked);
+    for (const toggle of toggles) toggle.checked = !allChecked;
+    selectAll.textContent = allChecked
+      ? t("settings.customProvider.selectAll")
+      : t("settings.customProvider.deselectAll");
+  });
+
+  baseUrl.addEventListener("blur", () => {
+    if (providerId.value.trim()) return;
+    const base = baseUrl.value.trim();
+    if (base) providerId.value = suggestProviderIdFromBaseUrl(base);
+  });
+
+  detectBtn.addEventListener("click", async () => {
+    if (!baseUrl.value.trim()) {
+      setStatus(t("settings.customProvider.baseUrlRequired"), "error");
+      return;
+    }
+    if (!apiKey.value.trim()) {
+      setStatus(t("settings.customProvider.keyRequired"), "error");
+      return;
+    }
+    detectBtn.disabled = true;
+    setStatus(t("settings.customProvider.detecting"));
+    try {
+      const resp = await call(
+        "detect_custom_provider",
+        {
+          baseUrl: baseUrl.value.trim(),
+          apiKey: apiKey.value.trim(),
+          preferred: protocol.value,
+        },
+        { timeoutMs: PROBE_TIMEOUT_MS },
+      );
+      if (!resp?.ok) throw new Error(resp?.error || t("settings.customProvider.detectFailed"));
+      const data = resp.data || {};
+      if (!data.protocol || data.protocol === "unknown") {
+        throw new Error(data.error || t("settings.customProvider.detectFailed"));
+      }
+      detectedProtocol = data.protocol;
+      if (protocol.value === "auto") protocol.value = data.protocol;
+      renderModels(data.models);
+      setStatus(
+        t("settings.customProvider.detected", {
+          protocol: data.protocol,
+          count: data.models?.length ?? 0,
+        }),
+        "ok",
+      );
+    } catch (error) {
+      detectedProtocol = null;
+      setStatus(error.message || String(error), "error");
+    } finally {
+      detectBtn.disabled = false;
+    }
+  });
+
+  testBtn.addEventListener("click", async () => {
+    const nextProtocol = resolvedProtocol();
+    if (!baseUrl.value.trim() || !apiKey.value.trim() || !nextProtocol) {
+      setStatus(t("settings.customProvider.detectFirst"), "error");
+      return;
+    }
+    testBtn.disabled = true;
+    setStatus(t("settings.customProvider.testing"));
+    try {
+      const selected = selectedModels();
+      const resp = await call(
+        "test_custom_provider",
+        {
+          baseUrl: baseUrl.value.trim(),
+          apiKey: apiKey.value.trim(),
+          protocol: nextProtocol,
+          modelId: selected[0]?.id,
+        },
+        { timeoutMs: PROBE_TIMEOUT_MS },
+      );
+      if (!resp?.ok) throw new Error(resp?.error || t("settings.customProvider.testFailed"));
+      if (!resp.data?.ok) {
+        throw new Error(resp.data?.error || t("settings.customProvider.testFailed"));
+      }
+      setStatus(t("settings.customProvider.testOk", { ms: resp.data.latencyMs ?? "—" }), "ok");
+    } catch (error) {
+      setStatus(error.message || String(error), "error");
+    } finally {
+      testBtn.disabled = false;
+    }
+  });
+
+  saveBtn.addEventListener("click", async () => {
+    const nextProtocol = resolvedProtocol();
+    if (!baseUrl.value.trim() || !apiKey.value.trim() || !nextProtocol) {
+      setStatus(t("settings.customProvider.detectFirst"), "error");
+      return;
+    }
+    const models = selectedModels();
+    if (models.length === 0) {
+      setStatus(t("settings.customProvider.modelsRequired"), "error");
+      return;
+    }
+    saveBtn.disabled = true;
+    setStatus(t("settings.customProvider.saving"));
+    try {
+      const resp = await call("save_custom_provider", {
+        providerId: providerId.value.trim(),
+        baseUrl: baseUrl.value.trim(),
+        apiKey: apiKey.value.trim(),
+        protocol: nextProtocol,
+        models,
+        storeKey: true,
+        includeApiKeyInFile: false,
+      });
+      if (!resp?.ok) throw new Error(resp?.error || t("settings.customProvider.saveFailed"));
+      const keyNote = resp.data?.keyStored
+        ? t("settings.customProvider.keyStored")
+        : t("settings.customProvider.keyNotStored");
+      setStatus(
+        t("settings.customProvider.saved", {
+          id: resp.data?.providerId || providerId.value.trim(),
+          count: resp.data?.modelCount ?? models.length,
+        }) + keyNote,
+        "ok",
+      );
+      await onSaved?.(resp.data?.providerId);
+      backdrop.remove();
+    } catch (error) {
+      setStatus(error.message || String(error), "error");
+      saveBtn.disabled = false;
+    }
+  });
+}

--- a/public/native/settings/settings-custom-provider.test.js
+++ b/public/native/settings/settings-custom-provider.test.js
@@ -1,0 +1,88 @@
+import { JSDOM } from "jsdom";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { openCustomProviderEditor } from "./settings-custom-provider.js";
+
+describe("custom provider editor", () => {
+  let dom;
+
+  beforeEach(() => {
+    dom = new JSDOM("<body></body>");
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    dom.window.close();
+    delete globalThis.window;
+    delete globalThis.document;
+  });
+
+  test("detects protocol, lists models, tests connectivity, and saves via picot-config", async () => {
+    const call = vi.fn(async (op) => {
+      if (op === "detect_custom_provider") {
+        return {
+          ok: true,
+          data: {
+            protocol: "openai-completions",
+            models: [{ id: "gpt-4o-mini", contextWindow: 32768 }, { id: "deepseek-v3" }],
+          },
+        };
+      }
+      if (op === "test_custom_provider") {
+        return { ok: true, data: { ok: true, latencyMs: 42 } };
+      }
+      if (op === "save_custom_provider") {
+        return {
+          ok: true,
+          data: { providerId: "example-com", modelCount: 2, keyStored: true },
+        };
+      }
+      throw new Error(`Unexpected op: ${op}`);
+    });
+    const onSaved = vi.fn();
+    const setupDialog = (title, subtitle) => {
+      const backdrop = document.createElement("div");
+      const dialog = document.createElement("div");
+      backdrop.appendChild(dialog);
+      document.body.appendChild(backdrop);
+      const heading = document.createElement("h2");
+      heading.textContent = title;
+      const caption = document.createElement("p");
+      caption.textContent = subtitle;
+      dialog.append(heading, caption);
+      return { backdrop, dialog };
+    };
+
+    openCustomProviderEditor({ call, setupDialog, onSaved });
+
+    const inputs = document.querySelectorAll(".provider-setup-form input");
+    inputs[1].value = "https://api.example.com/v1";
+    inputs[2].value = "sk-test";
+    document.querySelector(".provider-setup-actions .ui-button--secondary:nth-of-type(2)").click();
+
+    await vi.waitFor(() =>
+      expect(document.querySelectorAll(".custom-provider-model-toggle")).toHaveLength(2),
+    );
+    expect(document.querySelector("select").value).toBe("openai-completions");
+
+    document.querySelectorAll(".provider-setup-actions .ui-button--secondary")[2].click();
+    await vi.waitFor(() =>
+      expect(call).toHaveBeenCalledWith(
+        "test_custom_provider",
+        expect.objectContaining({ protocol: "openai-completions", modelId: "gpt-4o-mini" }),
+        expect.any(Object),
+      ),
+    );
+
+    document.querySelector(".provider-setup-actions .ui-button--primary").click();
+    await vi.waitFor(() => expect(onSaved).toHaveBeenCalledWith("example-com"));
+    const saveCall = call.mock.calls.find(([op]) => op === "save_custom_provider");
+    expect(saveCall[1]).toMatchObject({
+      protocol: "openai-completions",
+      storeKey: true,
+      includeApiKeyInFile: false,
+    });
+    expect(saveCall[1].models.map((model) => model.id)).toEqual(["gpt-4o-mini", "deepseek-v3"]);
+  });
+});

--- a/public/native/settings/settings-model-provider-editor.test.js
+++ b/public/native/settings/settings-model-provider-editor.test.js
@@ -251,6 +251,7 @@ describe("models provider editor", () => {
   test("add-provider dialog uses themed overlay primitives", async () => {
     const editor = setupSettingsConfig({ configGateway: { call } });
     await editor.loadInlineModelsEditor();
+    await editor.loadApiKeysPanel();
 
     document.querySelector(".models-provider-add").click();
     const dialog = document.querySelector(".provider-picker-dialog");
@@ -259,6 +260,12 @@ describe("models provider editor", () => {
     expect(dialog.closest(".ui-overlay.provider-picker-backdrop")).not.toBeNull();
     expect(dialog.querySelector(".ui-input.provider-picker-search")).not.toBeNull();
     expect(dialog.querySelector("#provider-picker-title").textContent).toBe("Add provider");
+    const sections = [...dialog.querySelectorAll(".provider-picker-section-title")].map(
+      (el) => el.dataset.section,
+    );
+    expect(sections[0]).toBe("builtIn");
+    expect(sections.at(-1)).toBe("custom");
+    expect(dialog.querySelector('[data-section="builtIn"]').textContent).not.toMatch(/API key/i);
   });
 });
 


### PR DESCRIPTION
…er error display

- Add `custom-provider-probe` helpers to detect protocol, list upstream models, test connectivity, and merge providers into `models.json`.
- Wire `save_custom_provider`, `detect_custom_provider`, and HTTP-based `check_model_health` into `picot-config`.
- Add provider picker and custom-provider editor UI with i18n strings (en/es/ja/zh).
- Extract and render provider/LLM failure messages from runtime events so users see why a model request failed.
- Add unit tests for probe logic, config operations, and assistant-error extraction.

ref: https://github.com/shixin-guo/picot/pull/21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom provider setup for OpenAI-compatible and Anthropic endpoints.
  * Detect available protocols and models, test connectivity, select models, and save provider configurations.
  * API keys can be stored securely outside the models configuration file.
  * Provider picker now groups built-in, subscription, and custom providers.
  * Added localized setup, validation, status, and error messages.

* **Bug Fixes**
  * Provider and runtime errors now appear clearly in assistant responses and conversation history.
  * Improved model health checks and settings-panel scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->