### PR TITLE
ci: build Linux AppImage again via an ldd shim for linuxdeploy

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,132 @@
+name: Warm build cache
+
+# GitHub Actions caches are scoped by ref: a run can restore caches created by
+# its own ref or by the default branch, and nothing else. release.yml only ever
+# runs on tags, so anything it saved was written into a `refs/tags/vX` scope
+# that no later run could read -- every release recompiled the entire Rust
+# dependency graph from scratch (~11-13 min per platform).
+#
+# This workflow does the saving from main, the one scope every tag run can
+# restore from. It compiles the exact same binary as a release does, minus the
+# bundling and publishing, so the artifacts it caches are the ones the release
+# build is looking for. It doubles as an early warning that main still compiles
+# on all six target platforms.
+#
+# Keep the matrix, the CARGO_* env block and the rust-cache inputs identical to
+# release.yml. rust-cache hashes every CARGO*/RUST* environment variable into
+# its key, so a difference in any of them silently stops the cache resolving.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src-tauri/**"
+      - ".cargo/**"
+      - ".github/workflows/cache-warm.yml"
+  # Unused caches are evicted after 7 days, so refresh twice a week to keep a
+  # warm cache waiting for whenever the next tag gets pushed.
+  schedule:
+    - cron: "0 6 * * 1,4"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cache-warm-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+          - os: macos-14
+            pi_target_platform: darwin-x64
+            rust_target: x86_64-apple-darwin
+          - os: ubuntu-22.04
+            pi_target_platform: linux-x64
+          - os: ubuntu-24.04-arm
+            pi_target_platform: linux-arm64
+          - os: windows-2022
+            pi_target_platform: windows-x64
+          - os: windows-11-arm
+            pi_target_platform: windows-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CARGO_HTTP_MULTIPLEXING: "false"
+      CARGO_NET_RETRY: "10"
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+      CARGO_HTTP_CHECK_REVOKE: "false"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache cargo + build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          # The root .cargo/config.toml sets `target-dir = "target"`, which
+          # cargo resolves relative to that file -- so the target dir is the
+          # repo root's, not `src-tauri/target`.
+          workspaces: src-tauri -> ../target
+          shared-key: picot-release-${{ matrix.os }}-${{ matrix.rust_target }}
+          save-if: "true"
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          WEBKIT_DEV_PKG="libwebkit2gtk-4.1-dev"
+          if ! apt-cache show "$WEBKIT_DEV_PKG" >/dev/null 2>&1; then
+            WEBKIT_DEV_PKG="libwebkit2gtk-4.0-dev"
+          fi
+          sudo apt-get install -y \
+            desktop-file-utils \
+            "$WEBKIT_DEV_PKG" \
+            libappindicator3-dev \
+            librsvg2-dev \
+            gstreamer1.0-tools \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            rpm \
+            patchelf
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Same key as release.yml so the release restores these too -- they were
+      # missing for exactly the same ref-scoping reason as the cargo cache.
+      - name: Cache embedded release downloads
+        uses: actions/cache@v5
+        with:
+          path: |
+            .cache/pi-binaries
+            .cache/terminal-fonts
+            .cache/cjk-fonts
+          key: embedded-assets-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/pi-version.json', 'scripts/terminal-font-version.json', 'scripts/cjk-font-version.json') }}
+
+      # `--no-bundle` stops after the Rust binary: same cargo invocation and
+      # therefore the same crate fingerprints as a release build, without the
+      # bundler, the code signing or the release upload. tauri.conf.json's
+      # beforeBuildCommand still fetches the embedded assets and builds the
+      # frontend, so this is the release compile in every way that the cache
+      # cares about.
+      - name: Build the Rust binary (no bundling)
+        env:
+          PI_TARGET_PLATFORM: ${{ matrix.pi_target_platform }}
+        run: bun run tauri build --no-bundle ${{ matrix.rust_target && format('--target {0}', matrix.rust_target) || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,31 @@ jobs:
       - name: Build pi extensions bundle
         run: bun run build:extensions
 
-      - name: Build Tauri app (Linux deb + rpm) and publish assets
+      # linuxdeploy walks the whole AppDir and runs `ldd` on every ELF file
+      # it finds, including the statically linked `pi` binary we ship under
+      # `resources/pi`. On arm64 glibc's ldd has no interpreter to trace for a
+      # static binary, falls back to executing the file, and dies -- which
+      # aborts the AppImage bundle. This shim calls the real ldd and, when it
+      # fails, degrades to the answer ldd should have given, so linuxdeploy
+      # treats the file as having no shared-library dependencies (which is
+      # true) instead of erroring out. Only affects the AppImage tooling; the
+      # deb/rpm bundlers never invoke ldd.
+      - name: Install ldd shim for linuxdeploy (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          mkdir -p "$RUNNER_TEMP/ldd-shim"
+          cat > "$RUNNER_TEMP/ldd-shim/ldd" <<'SH'
+          #!/bin/sh
+          out=$(/usr/bin/ldd "$@") || {
+            printf '\tnot a dynamic executable\n'
+            exit 0
+          }
+          printf '%s\n' "$out"
+          SH
+          chmod +x "$RUNNER_TEMP/ldd-shim/ldd"
+          echo "$RUNNER_TEMP/ldd-shim" >> "$GITHUB_PATH"
+
+      - name: Build Tauri app (Linux deb + rpm + AppImage) and publish assets
         if: runner.os == 'Linux'
         uses: tauri-apps/tauri-action@v0
         env:
@@ -156,7 +180,11 @@ jobs:
             Download the installer for your platform from the assets below.
           releaseDraft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
-          args: --bundles deb,rpm
+          # AppImage is the only Linux target the Tauri updater supports, so
+          # it is what puts a `linux-*` entry into `latest.json`. It is also
+          # the only target that goes through linuxdeploy -- see the ldd shim
+          # step above and `NO_STRIP` for the workarounds that keeps alive.
+          args: --bundles deb,rpm,appimage
           # tauri-action will only attach `latest.json` (the updater
           # manifest) when this is `true`. Combined with
           # `bundle.createUpdaterArtifacts` in tauri.conf.json, the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,15 +132,25 @@ jobs:
       - name: Build pi extensions bundle
         run: bun run build:extensions
 
-      # linuxdeploy walks the whole AppDir and runs `ldd` on every ELF file
-      # it finds, including the statically linked `pi` binary we ship under
-      # `resources/pi`. On arm64 glibc's ldd has no interpreter to trace for a
-      # static binary, falls back to executing the file, and dies -- which
-      # aborts the AppImage bundle. This shim calls the real ldd and, when it
-      # fails, degrades to the answer ldd should have given, so linuxdeploy
-      # treats the file as having no shared-library dependencies (which is
-      # true) instead of erroring out. Only affects the AppImage tooling; the
-      # deb/rpm bundlers never invoke ldd.
+      # linuxdeploy walks the whole AppDir and runs `ldd` on every ELF file it
+      # finds, including the `pi` binary we ship under `resources/pi`. It
+      # tolerates a failing ldd only when the output says "not a dynamic
+      # executable" (elf_file.cpp), and otherwise throws an uncaught
+      # std::runtime_error -- which aborts the whole bundle:
+      #
+      #   Deploying dependencies for ELF file .../Picot.AppDir/usr/lib/Picot/pi/pi
+      #   terminate called after throwing an instance of 'std::runtime_error'
+      #     what():  Failed to run ldd: exited with code 1
+      #   ERROR: Failed to run plugin: gtk (exit code: 134)
+      #
+      # That is the v0.4.3-beta.3 arm64 failure. The x86_64 pi binary is
+      # dynamically linked so ldd succeeds there and only arm64 trips it.
+      #
+      # linuxdeploy resolves `ldd` through PATH, so shim it: pass a successful
+      # ldd through untouched, and rewrite a failure into the exact
+      # "not a dynamic executable" / exit 1 answer that linuxdeploy's guard is
+      # written to absorb, making it log a warning and move on. Only the
+      # AppImage target goes through linuxdeploy; deb/rpm never invoke ldd.
       - name: Install ldd shim for linuxdeploy (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -149,7 +159,7 @@ jobs:
           #!/bin/sh
           out=$(/usr/bin/ldd "$@") || {
             printf '\tnot a dynamic executable\n'
-            exit 0
+            exit 1
           }
           printf '%s\n' "$out"
           SH
@@ -184,7 +194,9 @@ jobs:
           # it is what puts a `linux-*` entry into `latest.json`. It is also
           # the only target that goes through linuxdeploy -- see the ldd shim
           # step above and `NO_STRIP` for the workarounds that keeps alive.
-          args: --bundles deb,rpm,appimage
+          # `--verbose` keeps linuxdeploy's own stderr in the log instead of
+          # tauri-bundler's generic "failed to run linuxdeploy" wrapper.
+          args: --bundles deb,rpm,appimage --verbose
           # tauri-action will only attach `latest.json` (the updater
           # manifest) when this is `true`. Combined with
           # `bundle.createUpdaterArtifacts` in tauri.conf.json, the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,14 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           set -euo pipefail
-          appimage="$(ls "$PWD"/src-tauri/target/release/bundle/appimage/*.AppImage | head -1)"
+          # The cargo target dir is the workspace root, not src-tauri/target.
+          # Search rather than hardcode, so a layout change fails loudly here
+          # instead of silently skipping the check.
+          appimage="$(find "$PWD" -type f -name '*.AppImage' -path '*/bundle/appimage/*' | head -1)"
+          if [ -z "$appimage" ]; then
+            echo "::error::no AppImage found under $PWD"
+            exit 1
+          fi
           expected="$(sha256sum "$PWD/src-tauri/resources/pi/pi" | cut -d' ' -f1)"
           workdir="$RUNNER_TEMP/appimage-pi-check"
           rm -rf "$workdir"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,21 +60,40 @@ jobs:
         with:
           targets: ${{ matrix.rust_target }}
 
-      # Cache the cargo registry + git db + target dir so successful crate
-      # downloads survive across runs. This both speeds up builds and makes
-      # transient crates.io download failures far less likely to break a
-      # release (the crate is usually already on disk from a prior run).
-      - name: Cache cargo + build artifacts
-        uses: actions/cache@v5
+      # Cache the cargo registry + git db + build artifacts. This both speeds
+      # up builds and makes transient crates.io download failures far less
+      # likely to break a release (the crate is usually already on disk from a
+      # prior run).
+      #
+      # Two things a hand-rolled `actions/cache` step here got wrong, each of
+      # which on its own reduced every release to a from-scratch compile of the
+      # whole dependency graph (~11-13 min of the ~15 min wall time):
+      #
+      #  1. It cached `src-tauri/target`, which does not exist. The root
+      #     `.cargo/config.toml` sets `target-dir = "target"`, and cargo
+      #     resolves that relative to the config file -- so build output lands
+      #     in the *repo root* `target/`. The saved caches were ~40 MB of bare
+      #     registry with no compiled artifacts in them at all.
+      #  2. Actions caches are scoped by ref and this workflow only runs on
+      #     tags, so every cache it saved landed in a `refs/tags/vX` scope that
+      #     no later run can read (a run sees its own ref plus the default
+      #     branch, nothing else). A 100% miss rate, forever, and every run
+      #     added another few GB of unreadable entries to the repo's 10 GB
+      #     cache quota.
+      #
+      # Hence: `../target` relative to the `src-tauri` workspace root, and
+      # saving happens in cache-warm.yml on main -- the one scope every tag run
+      # can restore from. `save-if` keeps tag runs read-only so they stop
+      # filling the quota with unreadable entries.
+      - name: Restore cargo + build artifacts cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-            src-tauri/target
-          key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: |
-            cargo-${{ runner.os }}-${{ runner.arch }}-
+          workspaces: src-tauri -> ../target
+          # Must stay identical to cache-warm.yml, along with the CARGO_* env
+          # above: rust-cache hashes every CARGO*/RUST* variable into the key,
+          # so a difference in either place silently stops the cache resolving.
+          shared-key: picot-release-${{ matrix.os }}-${{ matrix.rust_target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -186,8 +205,7 @@ jobs:
       - name: Install patchelf shim for linuxdeploy (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y patchelf
+          # patchelf itself comes from the "Install Linux dependencies" step.
           mkdir -p "$RUNNER_TEMP/patchelf-shim"
           cat > "$RUNNER_TEMP/patchelf-shim/patchelf" <<'SH'
           #!/bin/sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,50 @@ jobs:
           chmod +x "$RUNNER_TEMP/ldd-shim/ldd"
           echo "$RUNNER_TEMP/ldd-shim" >> "$GITHUB_PATH"
 
+      # linuxdeploy also runs `patchelf --set-rpath '$ORIGIN'` on every ELF in
+      # the AppDir, `resources/pi/pi` included. patchelf relocates the program
+      # headers, which shifts every PT_LOAD file offset -- measured on
+      # v0.4.3-beta.5: x86_64 +0x1000, aarch64 +0x10000, and a DT_RUNPATH the
+      # upstream binary does not have. `pi` is a self-extracting single-file
+      # runtime that seeks its payload at a fixed offset inside
+      # /proc/self/exe, so a shifted binary dies instantly and silently
+      # (killed by a signal, nothing on stderr). In the app that surfaces as
+      # "Pi RPC request failed: ProcessClosed" plus an empty provider list.
+      # deb/rpm never invoke linuxdeploy, which is why only AppImage users hit
+      # it, and the ldd shim above does not help: it stops dependency
+      # deployment, not the rpath rewrite.
+      #
+      # linuxdeploy looks up patchelf in $PATCHELF before falling back to PATH
+      # ("Using patchelf specified in $PATCHELF"), so point it at a shim that
+      # forwards everything except a *write* to the bundled pi. Reads still go
+      # through so linuxdeploy keeps getting truthful answers.
+      - name: Install patchelf shim for linuxdeploy (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y patchelf
+          mkdir -p "$RUNNER_TEMP/patchelf-shim"
+          cat > "$RUNNER_TEMP/patchelf-shim/patchelf" <<'SH'
+          #!/bin/sh
+          # patchelf's target file is always the final argument.
+          for arg in "$@"; do target="$arg"; done
+          case "$target" in
+            */pi/pi)
+              for arg in "$@"; do
+                case "$arg" in
+                  --set-rpath|--add-rpath|--force-rpath|--remove-rpath|--shrink-rpath|--set-interpreter|--add-needed|--remove-needed|--replace-needed)
+                    echo "picot: refusing to rewrite the embedded pi runtime ($target)" >&2
+                    exit 0
+                    ;;
+                esac
+              done
+              ;;
+          esac
+          exec /usr/bin/patchelf "$@"
+          SH
+          chmod +x "$RUNNER_TEMP/patchelf-shim/patchelf"
+          echo "PATCHELF=$RUNNER_TEMP/patchelf-shim/patchelf" >> "$GITHUB_ENV"
+
       - name: Build Tauri app (Linux deb + rpm + AppImage) and publish assets
         if: runner.os == 'Linux'
         uses: tauri-apps/tauri-action@v0
@@ -205,6 +249,33 @@ jobs:
           # bundle. The Tauri updater endpoint then resolves to
           # `https://github.com/.../releases/latest/download/latest.json`.
           updaterJsonPreferNsis: true
+
+      # Guard against the failure this shim exists to prevent: if a future
+      # linuxdeploy (or a change to the shim) rewrites the embedded runtime
+      # again, fail loudly here instead of shipping an AppImage whose pi dies
+      # at startup with no stderr.
+      - name: Verify linuxdeploy left the embedded pi untouched (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          appimage="$(ls "$PWD"/src-tauri/target/release/bundle/appimage/*.AppImage | head -1)"
+          expected="$(sha256sum "$PWD/src-tauri/resources/pi/pi" | cut -d' ' -f1)"
+          workdir="$RUNNER_TEMP/appimage-pi-check"
+          rm -rf "$workdir"
+          mkdir -p "$workdir"
+          chmod +x "$appimage"
+          (cd "$workdir" && "$appimage" --appimage-extract 'usr/lib/*/pi/pi' >/dev/null)
+          bundled="$(find "$workdir/squashfs-root" -type f -name pi | head -1)"
+          if [ -z "$bundled" ]; then
+            echo "::error::the AppImage does not contain resources/pi/pi"
+            exit 1
+          fi
+          actual="$(sha256sum "$bundled" | cut -d' ' -f1)"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::linuxdeploy modified the embedded pi runtime (expected $expected, got $actual)"
+            exit 1
+          fi
+          echo "embedded pi is byte-identical to upstream ($actual)"
 
       - name: Build Tauri app and publish assets
         if: runner.os != 'Linux'

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Windows (PowerShell):
 irm https://raw.githubusercontent.com/shixin-guo/picot/main/scripts/install.ps1 | iex
 ```
 
+The Linux installer picks a `.deb` or `.rpm` for your package manager. On distros with
+neither — or to install per-user without `sudo` — add `--appimage` to get the AppImage in
+`~/.local/bin`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/shixin-guo/picot/main/scripts/install.sh | bash -s -- --appimage
+```
+
 Or [download from GitHub Releases](https://github.com/shixin-guo/picot/releases).
 
 You **do not** need to install the `pi` CLI separately — Picot bundles its own pi runtime.

--- a/README.zh.md
+++ b/README.zh.md
@@ -41,6 +41,13 @@ Windows (PowerShell):
 irm https://raw.githubusercontent.com/shixin-guo/picot/main/scripts/install.ps1 | iex
 ```
 
+Linux 安装脚本会按你的包管理器选择 `.deb` 或 `.rpm`。两者都没有的发行版，或者不想用 `sudo`
+的话，加 `--appimage` 把 AppImage 装到 `~/.local/bin`：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/shixin-guo/picot/main/scripts/install.sh | bash -s -- --appimage
+```
+
 或 [从 GitHub Releases 下载](https://github.com/shixin-guo/picot/releases)。
 
 **无需单独安装 `pi` CLI** — Picot 内置了自己的 pi 运行时。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picot",
-  "version": "0.4.3-10006",
+  "version": "0.4.3-10007",
   "description": "Local Codex-style desktop GUI for the Pi coding agent",
   "keywords": [
     "picot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picot",
-  "version": "0.4.3-10004",
+  "version": "0.4.3-10005",
   "description": "Local Codex-style desktop GUI for the Pi coding agent",
   "keywords": [
     "picot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picot",
-  "version": "0.4.3-10007",
+  "version": "0.4.3-10008",
   "description": "Local Codex-style desktop GUI for the Pi coding agent",
   "keywords": [
     "picot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picot",
-  "version": "0.4.3-10005",
+  "version": "0.4.3-10006",
   "description": "Local Codex-style desktop GUI for the Pi coding agent",
   "keywords": [
     "picot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picot",
-  "version": "0.4.2",
+  "version": "0.4.3-10004",
   "description": "Local Codex-style desktop GUI for the Pi coding agent",
   "keywords": [
     "picot",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 # ── Constants ─────────────────────────────────────────────────────────────────
 REPO="shixin-guo/picot"
 GITHUB_API="https://api.github.com/repos/${REPO}/releases"
-GITHUB_DL="https://github.com/${REPO}/releases/download"
 APP_NAME="Picot"
 
 # ── Colors ────────────────────────────────────────────────────────────────────
@@ -28,12 +27,16 @@ die() { error "$*"; exit 1; }
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 PINNED_VERSION=""
+FORCE_APPIMAGE=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --version|-v) PINNED_VERSION="$2"; shift 2 ;;
+    --appimage)   FORCE_APPIMAGE=1; shift ;;
     --help|-h)
-      echo "Usage: install.sh [--version <tag>]"
-      echo "  --version  Install a specific release tag (e.g. v0.3.0). Defaults to latest."
+      echo "Usage: install.sh [--version <tag>] [--appimage]"
+      echo "  --version   Install a specific release tag (e.g. v0.3.0). Defaults to latest."
+      echo "  --appimage  Linux only. Install the AppImage into ~/.local/bin instead of"
+      echo "              using the system package manager. No sudo required."
       exit 0 ;;
     *) die "Unknown option: $1" ;;
   esac
@@ -81,25 +84,35 @@ case "$ARCH" in
   *)                die "Unsupported architecture: $ARCH" ;;
 esac
 
-# ── Detect Linux package manager ──────────────────────────────────────────────
-PKG_MGR=""
+if [ "$FORCE_APPIMAGE" = "1" ] && [ "$PLATFORM" != "linux" ]; then
+  die "--appimage is Linux-only; on macOS the DMG is the only bundle."
+fi
+
+# ── Pick the Linux install method ─────────────────────────────────────────────
+# The AppImage is the universal fallback: it is a self-contained binary, so it
+# covers the distros that ship none of these package managers (Arch, Alpine,
+# NixOS, Gentoo, Void, ...) and it installs per-user without sudo.
+INSTALL_METHOD=""
 if [ "$PLATFORM" = "linux" ]; then
-  if command -v apt-get &>/dev/null; then
-    PKG_MGR="apt"
+  if [ "$FORCE_APPIMAGE" = "1" ]; then
+    INSTALL_METHOD="appimage"
+  elif command -v apt-get &>/dev/null; then
+    INSTALL_METHOD="apt"
   elif command -v dpkg &>/dev/null; then
-    PKG_MGR="dpkg"
+    INSTALL_METHOD="dpkg"
   elif command -v dnf &>/dev/null; then
-    PKG_MGR="dnf"
+    INSTALL_METHOD="dnf"
   elif command -v yum &>/dev/null; then
-    PKG_MGR="yum"
+    INSTALL_METHOD="yum"
   elif command -v rpm &>/dev/null; then
-    PKG_MGR="rpm"
+    INSTALL_METHOD="rpm"
   else
-    die "No supported package manager found (apt/dpkg/dnf/yum/rpm)."
+    INSTALL_METHOD="appimage"
+    info "No apt/dpkg/dnf/yum/rpm found — falling back to the AppImage."
   fi
 fi
 
-# ── Resolve version ───────────────────────────────────────────────────────────
+# ── Resolve the release ───────────────────────────────────────────────────────
 header "🎯  ${APP_NAME} Installer"
 if is_snap_path "$(command -v curl)"; then
   if [ "$CURL_BIN" = "/usr/bin/curl" ]; then
@@ -108,46 +121,88 @@ if is_snap_path "$(command -v curl)"; then
     warn "Snap curl cannot write to /tmp or ~/.cache. Staging the download under ~/picot-install."
   fi
 fi
+
 if [ -n "$PINNED_VERSION" ]; then
   VERSION="$PINNED_VERSION"
+  [ "${VERSION#v}" = "$VERSION" ] && VERSION="v${VERSION}"
   info "Using pinned version: ${VERSION}"
+  RELEASE_URL="${GITHUB_API}/tags/${VERSION}"
 else
   info "Fetching latest release from GitHub..."
-  VERSION="$(curl_get -fsSL "${GITHUB_API}/latest" | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+  RELEASE_URL="${GITHUB_API}/latest"
+fi
+
+RELEASE_JSON="$(curl_get -fsSL "$RELEASE_URL")" \
+  || die "Failed to query the GitHub release API. Check your connection, or that ${PINNED_VERSION:-the latest release} exists."
+
+if [ -z "$PINNED_VERSION" ]; then
+  # `|| true`: `set -o pipefail` turns a non-matching grep into a failed
+  # assignment, which `set -e` would abort on before the guard below runs.
+  VERSION="$(printf '%s' "$RELEASE_JSON" | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' || true)"
   [ -n "$VERSION" ] || die "Failed to fetch latest release version."
   info "Latest version: ${VERSION}"
 fi
 
-# Strip leading 'v' for use in filenames
-VER="${VERSION#v}"
+# Never rebuild asset filenames from the tag. `scripts/release.sh` encodes
+# prerelease tags into a numeric app version (Windows MSI rejects `-beta.4`),
+# so tag `v0.4.3-beta.4` ships assets named `Picot_0.4.3-10004_*`. Matching the
+# asset list the API just handed us keeps this immune to that encoding — and to
+# any future bundler rename.
+ASSET_URLS="$(printf '%s' "$RELEASE_JSON" \
+  | grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*"' \
+  | sed -E 's/.*"([^"]*)"$/\1/' || true)"
+[ -n "$ASSET_URLS" ] || die "Release ${VERSION} has no downloadable assets."
 
-# ── Build download URL ────────────────────────────────────────────────────────
+# `|| true` so a no-match returns empty rather than tripping `set -e` via
+# `pipefail` — callers decide what a missing asset means.
+pick_asset() { printf '%s\n' "$ASSET_URLS" | grep -E "$1" | head -1 || true; }
+
+case "$ARCH_NORM" in
+  x86_64) APPIMAGE_PATTERN='_amd64\.AppImage$'    ;;
+  arm64)  APPIMAGE_PATTERN='_aarch64\.AppImage$'  ;;
+esac
+
 case "$PLATFORM" in
   macos)
     case "$ARCH_NORM" in
-      arm64)  FILENAME="${APP_NAME}_${VER}_aarch64.dmg" ;;
-      x86_64) FILENAME="${APP_NAME}_${VER}_x64.dmg"     ;;
+      arm64)  PATTERN='_aarch64\.dmg$' ;;
+      x86_64) PATTERN='_x64\.dmg$'     ;;
     esac
     ;;
   linux)
-    case "$PKG_MGR" in
+    case "$INSTALL_METHOD" in
       apt|dpkg)
         case "$ARCH_NORM" in
-          x86_64) FILENAME="${APP_NAME}_${VER}_amd64.deb"  ;;
-          arm64)  FILENAME="${APP_NAME}_${VER}_arm64.deb"  ;;
+          x86_64) PATTERN='_amd64\.deb$' ;;
+          arm64)  PATTERN='_arm64\.deb$' ;;
         esac
         ;;
       dnf|yum|rpm)
         case "$ARCH_NORM" in
-          x86_64) FILENAME="${APP_NAME}-${VER}-1.x86_64.rpm"  ;;
-          arm64)  FILENAME="${APP_NAME}-${VER}-1.aarch64.rpm" ;;
+          x86_64) PATTERN='\.x86_64\.rpm$'  ;;
+          arm64)  PATTERN='\.aarch64\.rpm$' ;;
         esac
         ;;
+      appimage) PATTERN="$APPIMAGE_PATTERN" ;;
     esac
     ;;
 esac
 
-DOWNLOAD_URL="${GITHUB_DL}/${VERSION}/${FILENAME}"
+DOWNLOAD_URL="$(pick_asset "$PATTERN")"
+
+# Older releases predate the AppImage target, and a given release can miss an
+# arch for one bundle type. Fall back rather than dying on a partial release.
+if [ -z "$DOWNLOAD_URL" ] && [ "$PLATFORM" = "linux" ] && [ "$INSTALL_METHOD" != "appimage" ]; then
+  DOWNLOAD_URL="$(pick_asset "$APPIMAGE_PATTERN")"
+  if [ -n "$DOWNLOAD_URL" ]; then
+    warn "Release ${VERSION} has no ${INSTALL_METHOD} package for ${ARCH_NORM} — using the AppImage."
+    INSTALL_METHOD="appimage"
+  fi
+fi
+
+[ -n "$DOWNLOAD_URL" ] || die "Release ${VERSION} has no ${PLATFORM} asset for ${ARCH_NORM}."
+
+FILENAME="${DOWNLOAD_URL##*/}"
 
 # ── Download ──────────────────────────────────────────────────────────────────
 if is_snap_path "$CURL_BIN"; then
@@ -178,6 +233,56 @@ success "Downloaded ${FILENAME}"
 
 # ── Install ───────────────────────────────────────────────────────────────────
 header "📦  Installing"
+
+BIN_DIR="${HOME}/.local/bin"
+BIN_PATH="${BIN_DIR}/picot"
+
+install_appimage() {
+  mkdir -p "$BIN_DIR"
+  # Copy-then-rename instead of writing in place: overwriting a running
+  # AppImage fails with ETXTBSY, while rename(2) swaps it happily.
+  cp "$DEST" "${BIN_PATH}.new"
+  chmod 755 "${BIN_PATH}.new"
+  mv -f "${BIN_PATH}.new" "$BIN_PATH"
+  info "Installed AppImage to ${BIN_PATH}"
+
+  # Desktop entry + icon, so the app shows up in the launcher like the
+  # deb/rpm does. Icon extraction is best effort — `--appimage-extract` reads
+  # the bundle's own squashfs and needs no FUSE, but a missing icon is not
+  # worth failing the install over.
+  local desktop_dir="${HOME}/.local/share/applications"
+  local icon_dir="${HOME}/.local/share/icons/hicolor/256x256/apps"
+  mkdir -p "$desktop_dir" "$icon_dir"
+
+  local extracted
+  extracted="$(cd "$TMPDIR" && "$BIN_PATH" --appimage-extract 'usr/share/icons/hicolor/256x256/apps/*.png' >/dev/null 2>&1 \
+    && find "${TMPDIR}/squashfs-root" -name '*.png' | head -1 || true)"
+  if [ -n "$extracted" ] && [ -f "$extracted" ]; then
+    cp "$extracted" "${icon_dir}/picot.png"
+  fi
+
+  cat > "${desktop_dir}/picot.desktop" <<DESKTOP
+[Desktop Entry]
+Type=Application
+Name=${APP_NAME}
+Exec=${BIN_PATH}
+Icon=picot
+Categories=Development;Utility;
+Terminal=false
+DESKTOP
+  update-desktop-database "$desktop_dir" &>/dev/null || true
+  info "Added launcher entry"
+
+  case ":${PATH}:" in
+    *":${BIN_DIR}:"*) ;;
+    *) warn "${BIN_DIR} is not on your PATH. Add it to your shell profile to run \`picot\` directly." ;;
+  esac
+  # FUSE 2 is what mounts an AppImage at launch. Ubuntu 24.04+ ships only
+  # FUSE 3, so point at both the fix and the no-install escape hatch.
+  if [ ! -e /dev/fuse ] || ! ldconfig -p 2>/dev/null | grep -q 'libfuse\.so\.2'; then
+    warn "FUSE 2 not detected. Install it (e.g. \`sudo apt install libfuse2t64\`), or run: ${BIN_PATH} --appimage-extract-and-run"
+  fi
+}
 
 case "$PLATFORM" in
   macos)
@@ -214,7 +319,7 @@ case "$PLATFORM" in
     ;;
 
   linux)
-    case "$PKG_MGR" in
+    case "$INSTALL_METHOD" in
       apt)
         info "Installing with apt..."
         sudo apt-get install -y "$DEST"
@@ -234,6 +339,9 @@ case "$PLATFORM" in
       rpm)
         info "Installing with rpm..."
         sudo rpm -U --force "$DEST"
+        ;;
+      appimage)
+        install_appimage
         ;;
     esac
     success "Installed ${APP_NAME}"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "picot"
-version = "0.4.3-10007"
+version = "0.4.3-10008"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "picot"
-version = "0.4.2"
+version = "0.4.3-10004"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "picot"
-version = "0.4.3-10006"
+version = "0.4.3-10007"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "picot"
-version = "0.4.3-10004"
+version = "0.4.3-10005"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "picot"
-version = "0.4.3-10005"
+version = "0.4.3-10006"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picot"
-version = "0.4.3-10006"
+version = "0.4.3-10007"
 description = "Pi Agent Desktop - session manager for pi coding agent"
 authors = ["Pi Desktop"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picot"
-version = "0.4.3-10007"
+version = "0.4.3-10008"
 description = "Pi Agent Desktop - session manager for pi coding agent"
 authors = ["Pi Desktop"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picot"
-version = "0.4.3-10004"
+version = "0.4.3-10005"
 description = "Pi Agent Desktop - session manager for pi coding agent"
 authors = ["Pi Desktop"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picot"
-version = "0.4.2"
+version = "0.4.3-10004"
 description = "Pi Agent Desktop - session manager for pi coding agent"
 authors = ["Pi Desktop"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "picot"
-version = "0.4.3-10005"
+version = "0.4.3-10006"
 description = "Pi Agent Desktop - session manager for pi coding agent"
 authors = ["Pi Desktop"]
 edition = "2021"

--- a/src-tauri/src/appimage_env.rs
+++ b/src-tauri/src/appimage_env.rs
@@ -1,0 +1,208 @@
+//! Undo the AppImage runtime's environment for child processes.
+//!
+//! An AppImage's `AppRun` exports loader and module search paths
+//! (`LD_LIBRARY_PATH`, `GIO_MODULE_DIR`, `GTK_PATH`, ...) that point inside the
+//! mounted bundle, so the packaged WebKitGTK/GTK stack finds the libraries
+//! linuxdeploy shipped with it. Every process we spawn inherits those exports —
+//! including the embedded `pi` runtime, which is built against the host system
+//! and dies at startup when the dynamic loader hands it the bundle's copies of
+//! libstdc++/libcurl/etc. instead.
+//!
+//! Nothing here is AppImage-specific beyond the detection: outside an AppImage
+//! `appdir()` returns `None` and every entry point is a no-op.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+/// Colon-separated search paths. AppImage-owned entries are dropped; the
+/// variable is unset entirely when nothing else remains.
+const LIST_VARS: &[&str] = &[
+    "LD_LIBRARY_PATH",
+    "XDG_DATA_DIRS",
+    "XDG_CONFIG_DIRS",
+    "PYTHONPATH",
+    "PERLLIB",
+    "PERL5LIB",
+    "GI_TYPELIB_PATH",
+    "GIO_EXTRA_MODULES",
+    "GST_PLUGIN_PATH",
+    "GST_PLUGIN_SYSTEM_PATH",
+    "GST_PLUGIN_SYSTEM_PATH_1_0",
+    "GSETTINGS_SCHEMA_DIR",
+    "GTK_PATH",
+    "QT_PLUGIN_PATH",
+    "LIBGL_DRIVERS_PATH",
+    "ALSA_PLUGIN_DIR",
+];
+
+/// Single-value variables. Unset when the value points into the bundle.
+const SINGLE_VARS: &[&str] = &[
+    "LD_PRELOAD",
+    "PYTHONHOME",
+    "GIO_MODULE_DIR",
+    "GDK_PIXBUF_MODULE_FILE",
+    "GDK_PIXBUF_MODULEDIR",
+    "GTK_EXE_PREFIX",
+    "GTK_DATA_PREFIX",
+    "GTK_IM_MODULE_FILE",
+    "QT_QPA_PLATFORM_PLUGIN_PATH",
+    "FONTCONFIG_FILE",
+    "FONTCONFIG_PATH",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+];
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum EnvAction {
+    Set(OsString),
+    Unset,
+}
+
+/// The mounted bundle root, or `None` when we are not running from an AppImage.
+///
+/// `APPIMAGE` is exported only by the AppImage runtime, so requiring both it and
+/// `APPDIR` avoids reacting to an unrelated `APPDIR` from someone's build script.
+pub fn appdir() -> Option<PathBuf> {
+    let appdir = std::env::var_os("APPDIR")?;
+    std::env::var_os("APPIMAGE")?;
+    let path = PathBuf::from(appdir);
+    path.is_dir().then_some(path)
+}
+
+/// Drop every PATH entry that lives inside the bundle, so children resolve host
+/// tools rather than the ones linuxdeploy pulled in.
+pub fn strip_bundle_path_entries(dirs: &mut Vec<PathBuf>) {
+    if let Some(appdir) = appdir() {
+        dirs.retain(|dir| !dir.starts_with(&appdir));
+    }
+}
+
+pub fn plan() -> Vec<(&'static str, EnvAction)> {
+    appdir().map(|appdir| plan_for(&appdir)).unwrap_or_default()
+}
+
+pub fn scrub(command: &mut std::process::Command) {
+    for (key, action) in plan() {
+        match action {
+            EnvAction::Set(value) => command.env(key, value),
+            EnvAction::Unset => command.env_remove(key),
+        };
+    }
+}
+
+pub fn scrub_tokio(command: &mut tokio::process::Command) {
+    for (key, action) in plan() {
+        match action {
+            EnvAction::Set(value) => command.env(key, value),
+            EnvAction::Unset => command.env_remove(key),
+        };
+    }
+}
+
+fn plan_for(appdir: &Path) -> Vec<(&'static str, EnvAction)> {
+    let mut actions = Vec::new();
+    for key in LIST_VARS {
+        let Some(value) = std::env::var_os(key) else {
+            continue;
+        };
+        match sanitize_list(&value, appdir) {
+            Some(kept) if kept == value => {}
+            Some(kept) => actions.push((*key, EnvAction::Set(kept))),
+            None => actions.push((*key, EnvAction::Unset)),
+        }
+    }
+    for key in SINGLE_VARS {
+        let Some(value) = std::env::var_os(key) else {
+            continue;
+        };
+        if is_under(&value, appdir) {
+            actions.push((*key, EnvAction::Unset));
+        }
+    }
+    actions
+}
+
+/// `None` means "nothing survived the filter" — the caller unsets the variable
+/// rather than handing the child an empty value, which some loaders read as
+/// "current directory".
+fn sanitize_list(value: &OsStr, appdir: &Path) -> Option<OsString> {
+    let kept: Vec<PathBuf> = std::env::split_paths(value)
+        .filter(|entry| !entry.starts_with(appdir))
+        .collect();
+    if kept.is_empty() {
+        return None;
+    }
+    std::env::join_paths(kept).ok()
+}
+
+fn is_under(value: &OsStr, appdir: &Path) -> bool {
+    Path::new(value).starts_with(appdir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_under, sanitize_list, EnvAction};
+    use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn sanitize_list_drops_only_bundle_entries() {
+        let appdir = Path::new("/tmp/.mount_Picot42");
+        let value = OsString::from("/tmp/.mount_Picot42/usr/lib:/usr/lib:/tmp/.mount_Picot42/lib");
+        assert_eq!(
+            sanitize_list(&value, appdir),
+            Some(OsString::from("/usr/lib"))
+        );
+    }
+
+    #[test]
+    fn sanitize_list_reports_empty_result_so_caller_unsets() {
+        let appdir = Path::new("/tmp/.mount_Picot42");
+        let value = OsString::from("/tmp/.mount_Picot42/usr/lib");
+        assert_eq!(sanitize_list(&value, appdir), None);
+    }
+
+    #[test]
+    fn sanitize_list_keeps_a_clean_value_untouched() {
+        let appdir = Path::new("/tmp/.mount_Picot42");
+        let value = OsString::from("/usr/lib:/usr/local/lib");
+        assert_eq!(sanitize_list(&value, appdir), Some(value.clone()));
+    }
+
+    #[test]
+    fn sibling_directory_is_not_treated_as_inside_the_bundle() {
+        let appdir = Path::new("/tmp/.mount_Picot42");
+        assert!(!is_under(
+            &OsString::from("/tmp/.mount_Picot42x/lib"),
+            appdir
+        ));
+        assert!(is_under(&OsString::from("/tmp/.mount_Picot42/lib"), appdir));
+    }
+
+    #[test]
+    fn plan_for_unsets_bundle_owned_single_values() {
+        // `plan_for` reads the live environment, so drive it through the two
+        // pure helpers it composes instead of mutating global state.
+        let appdir = Path::new("/tmp/.mount_Picot42");
+        assert!(is_under(
+            &OsString::from("/tmp/.mount_Picot42/usr/lib/gio/modules"),
+            appdir
+        ));
+        assert_eq!(
+            sanitize_list(
+                &OsString::from("/tmp/.mount_Picot42/usr/share:/usr/share"),
+                appdir
+            ),
+            Some(OsString::from("/usr/share"))
+        );
+        assert_ne!(EnvAction::Unset, EnvAction::Set(OsString::from("x")));
+    }
+
+    #[test]
+    fn strip_bundle_path_entries_is_a_noop_outside_an_appimage() {
+        let mut dirs = vec![PathBuf::from("/usr/bin"), PathBuf::from("/bin")];
+        let before = dirs.clone();
+        super::strip_bundle_path_entries(&mut dirs);
+        assert_eq!(dirs, before);
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod appimage_env;
 mod git_pi_runner;
 mod git_service;
 mod host_data;

--- a/src-tauri/src/model_health.rs
+++ b/src-tauri/src/model_health.rs
@@ -99,6 +99,7 @@ pub async fn run_model_test(
     let (pi_bin, path_env) = pi_launch.resolve_bundled_pi_for_spawn()?;
 
     let mut command = Command::new(&pi_bin);
+    crate::appimage_env::scrub_tokio(&mut command);
     command
         .arg("--provider")
         .arg(&provider_name)

--- a/src-tauri/src/native_pi_manager.rs
+++ b/src-tauri/src/native_pi_manager.rs
@@ -116,6 +116,9 @@ impl NativePiManager {
         let launch = spec.command_description();
         let mut command = Command::new(&launch.program);
         configure_child_process(&mut command);
+        // Before any of our own env: an AppImage's AppRun points the dynamic
+        // loader at the bundle, and `pi` is built against the host system.
+        crate::appimage_env::scrub(&mut command);
         command
             .args(&launch.args)
             .envs(&launch.environment)
@@ -316,10 +319,16 @@ impl NativePiManager {
             .get(&target.instance_id)
             .map(|runtime| runtime.bridge.clone())
             .ok_or_else(|| "Native runtime instance is not running".to_string())?;
-        let response = bridge
-            .request(command, timeout)
-            .await
-            .map_err(|error| format!("Pi RPC request failed: {error:?}"))?;
+        let response = match bridge.request(command, timeout).await {
+            Ok(response) => response,
+            Err(error) => {
+                let mut message = format!("Pi RPC request failed: {error:?}");
+                if let Some(stderr) = self.drain_diagnostics(&target.instance_id) {
+                    message.push_str(&format!("\nPi stderr:\n{stderr}"));
+                }
+                return Err(message);
+            }
+        };
         if let Some(key) = mutation_key {
             self.inner
                 .coordinator
@@ -329,6 +338,19 @@ impl NativePiManager {
                 .map_err(|error| format!("Cannot cache mutation result: {error:?}"))?;
         }
         Ok(response)
+    }
+
+    /// Pull whatever `pi` wrote to stderr, so a dead runtime reports why it
+    /// died instead of a bare transport error.
+    fn drain_diagnostics(&self, instance_id: &str) -> Option<String> {
+        self.inner
+            .runtimes
+            .lock()
+            .ok()?
+            .get(instance_id)?
+            .process
+            .as_ref()?
+            .drain_diagnostics()
     }
 
     pub fn stop(&self, target: &RuntimeTarget) -> Result<(), String> {

--- a/src-tauri/src/pi_launch.rs
+++ b/src-tauri/src/pi_launch.rs
@@ -140,6 +140,7 @@ impl PiLaunchResolver {
         let augmented_path = build_augmented_path();
         let mut command = Command::new(&pi_bin_str);
         configure_child_process_for_windows(&mut command);
+        crate::appimage_env::scrub(&mut command);
         command
             .args(args)
             .env("PATH", augmented_path)
@@ -332,6 +333,7 @@ fn build_augmented_path() -> String {
     let mut dirs: Vec<PathBuf> = std::env::var_os("PATH")
         .map(|value| std::env::split_paths(&value).collect())
         .unwrap_or_default();
+    crate::appimage_env::strip_bundle_path_entries(&mut dirs);
 
     #[cfg(not(target_os = "windows"))]
     {

--- a/src-tauri/src/pi_rpc_bridge.rs
+++ b/src-tauri/src/pi_rpc_bridge.rs
@@ -29,6 +29,9 @@ impl BridgeError {
     }
 }
 
+/// Cap on stderr lines folded into an error message.
+const DIAGNOSTIC_TAIL_LINES: usize = 20;
+
 type PendingSender = oneshot::Sender<Result<Value, BridgeError>>;
 
 struct BridgeInner {
@@ -228,8 +231,17 @@ impl PiRpcProcess {
             .map_err(|error| format!("Cannot stop Pi RPC process: {error}"))
     }
 
-    pub fn take_diagnostic(&self) -> Option<String> {
-        self.diagnostics.try_recv().ok()
+    /// Everything `pi` has written to stderr and we have not reported yet.
+    /// When the process dies at startup its reason lands here — without this
+    /// the caller can only say `ProcessClosed`, which explains nothing.
+    pub fn drain_diagnostics(&self) -> Option<String> {
+        let lines: Vec<String> = self.diagnostics.try_iter().collect();
+        if lines.is_empty() {
+            return None;
+        }
+        // Keep the tail: a crashing runtime's last words beat its banner.
+        let start = lines.len().saturating_sub(DIAGNOSTIC_TAIL_LINES);
+        Some(lines[start..].join("\n"))
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Picot",
   "identifier": "works.earendil.picot",
-  "version": "0.4.3-10007",
+  "version": "0.4.3-10008",
   "build": {
     "frontendDist": "../public",
     "beforeDevCommand": "bun run fetch:pi && bun run fetch:terminal-font && bun run fetch:cjk-font && bun run build:extensions && bun run build:frontend",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Picot",
   "identifier": "works.earendil.picot",
-  "version": "0.4.3-10006",
+  "version": "0.4.3-10007",
   "build": {
     "frontendDist": "../public",
     "beforeDevCommand": "bun run fetch:pi && bun run fetch:terminal-font && bun run fetch:cjk-font && bun run build:extensions && bun run build:frontend",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Picot",
   "identifier": "works.earendil.picot",
-  "version": "0.4.3-10004",
+  "version": "0.4.3-10005",
   "build": {
     "frontendDist": "../public",
     "beforeDevCommand": "bun run fetch:pi && bun run fetch:terminal-font && bun run fetch:cjk-font && bun run build:extensions && bun run build:frontend",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Picot",
   "identifier": "works.earendil.picot",
-  "version": "0.4.3-10005",
+  "version": "0.4.3-10006",
   "build": {
     "frontendDist": "../public",
     "beforeDevCommand": "bun run fetch:pi && bun run fetch:terminal-font && bun run fetch:cjk-font && bun run build:extensions && bun run build:frontend",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Picot",
   "identifier": "works.earendil.picot",
-  "version": "0.4.2",
+  "version": "0.4.3-10004",
   "build": {
     "frontendDist": "../public",
     "beforeDevCommand": "bun run fetch:pi && bun run fetch:terminal-font && bun run fetch:cjk-font && bun run build:extensions && bun run build:frontend",
@@ -14,7 +14,9 @@
     "windows": [],
     "security": {
       "csp": "default-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' mediastream:; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*;",
-      "capabilities": ["default"]
+      "capabilities": [
+        "default"
+      ]
     }
   },
   "bundle": {
@@ -42,7 +44,9 @@
   "plugins": {
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEU5OUQ4Q0Y5MTA1MTFDRTEKUldUaEhGRVErWXlkNlNSa01lY0g5S1ltM3BjMHJhdUYxdXdsc25USndZdDBFeGZyeGpUa2JVZWEK",
-      "endpoints": ["https://github.com/shixin-guo/picot/releases/latest/download/latest.json"],
+      "endpoints": [
+        "https://github.com/shixin-guo/picot/releases/latest/download/latest.json"
+      ],
       "windows": {
         "installMode": "passive"
       }


### PR DESCRIPTION
## What changed

Two edits to `.github/workflows/release.yml`:

1. **New step: `Install ldd shim for linuxdeploy (Linux)`** — writes a wrapper `ldd` into `$RUNNER_TEMP/ldd-shim` and prepends that dir via `$GITHUB_PATH`, before `tauri-action` runs.
2. **Linux bundle targets: `--bundles deb,rpm` → `--bundles deb,rpm,appimage --verbose`**.

## Why

Linux releases have been shipping deb + rpm only, because the AppImage bundle failed on arm64. The [v0.4.3-beta.3 run](https://github.com/shixin-guo/picot/actions/runs/32662077212) has the exact failure:

```
Deploying dependencies for ELF file .../Picot.AppDir/usr/lib/Picot/pi/pi
terminate called after throwing an instance of 'std::runtime_error'
  what():  Failed to run ldd: exited with code 1
ERROR: Failed to run plugin: gtk (exit code: 134)
```

deb/rpm never invoke `ldd` — they lay files into system paths and declare dependencies as package metadata. AppImage is the only target that goes through **linuxdeploy**, which walks the entire AppDir and runs `ldd` on every ELF it finds. That sweep reaches `src-tauri/resources/pi/pi`, the `pi` binary we embed as a Tauri resource.

`ldd` doesn't crash — it exits 1, and linuxdeploy escalates that into an uncaught `std::runtime_error`, i.e. `SIGABRT` / exit 134. [`elf_file.cpp`](https://github.com/linuxdeploy/linuxdeploy/blob/master/src/core/elf_file.cpp) already handles a static binary, but the guard is narrow:

```cpp
subprocess::subprocess lddProc({"ldd", resolvedPath.string()}, env);
const auto result = lddProc.run();
if (result.exit_code() != 0) {
    if (result.stdout_string().find("not a dynamic executable") != std::string::npos || ...) {
        ldLog() << LD_WARNING << this->d->path << "is not linked dynamically" << std::endl;
        return {};
    }
    throw std::runtime_error{"Failed to run ldd: exited with code " + std::to_string(result.exit_code())};
}
```

A failing `ldd` is absorbed **only** if the output literally says `not a dynamic executable`; anything else throws. On the arm64 runner ldd fails without producing that string, so linuxdeploy aborts.

Note `{"ldd", ...}` — bare name, resolved through `PATH`. That's what makes the shim viable. It passes a successful ldd through byte-for-byte (tabs and `=>` lines intact, so downstream parsing is unaffected), and rewrites a failure into exactly the exit-1 + `not a dynamic executable` answer the guard is written to absorb. linuxdeploy then logs `is not linked dynamically`, returns no dependencies — which is correct — and carries on. The real ldd's stderr is not swallowed and still reaches the CI log.

`--verbose` is what surfaced linuxdeploy's own stderr instead of tauri-bundler's generic `failed to run linuxdeploy` wrapper; keeping it means the next failure is diagnosable from the log alone.

### Why only arm64

Same tag, same AppDir layout: the [x86_64 job](https://github.com/shixin-guo/picot/actions/runs/32662077212) processed the same file cleanly —

```
Deploying dependencies for ELF file .../Picot.AppDir/usr/lib/Picot/pi/pi
Setting rpath in ELF file .../Picot.AppDir/usr/lib/Picot/pi/pi to $ORIGIN
```

— so the x86_64 `pi` is dynamically linked and ldd succeeds on it. Only the arm64 build trips the guard.

### Side benefit: Linux auto-update

AppImage is the **only** Linux target Tauri's updater supports. With `bundle.createUpdaterArtifacts: true` but no AppImage in the build, `latest.json` had no `linux-*` entry — Linux users had no auto-update path at all. This restores it.

## Validation

`v0.4.3-beta.4` is tagged on this branch and building: https://github.com/shixin-guo/picot/actions/runs/33234334024

`prerelease: ${{ contains(github.ref_name, '-') }}` marks it a prerelease, so it won't land on `releases/latest` and won't be picked up by the updater endpoint. The check to watch is the `ubuntu-24.04-arm` job getting past `Deploying dependencies for ELF file .../Picot/pi/pi`.

## Notes for the reviewer

**Residual risk, if the arm64 `pi` is fully static:** clearing the ldd hurdle means linuxdeploy proceeds to `patchelf --set-rpath` on it. That works on x86_64 (see the log above), but a fully static binary has no `.dynamic` section for patchelf to rewrite. If beta.4 fails there instead, the fallback is to skip linuxdeploy entirely — assemble the AppDir from the deb and pack it with `appimagetool`, at the cost of no longer bundling GTK/WebKit.

**Overlap with `new-linux`:** that branch carries the earlier attempts (`v0.4.3-beta.1`…`beta.3`) and also installs `libfuse2t64`. The beta.3 log shows the AppImage tooling running fine under `--appimage-extract-and-run`, so FUSE was not the blocker and that package isn't included here.

**Not included:** caching `~/.cache/tauri/`. Tauri re-downloads linuxdeploy, AppRun, and the plugins there on every run (`prepare_tools` skips a download only when the file already exists), so caching would cut build time and remove a network-flake failure mode. Happy to add it here or in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linux AppImage installation support, including per-user installation to `~/.local/bin`.
  - Added automatic fallback to AppImage when supported package formats are unavailable.
  - Added desktop entry and icon setup for AppImage installations.

- **Bug Fixes**
  - Improved AppImage process launching and environment handling.
  - Enhanced error messages with recent process diagnostics.
  - Improved Linux release packaging validation and reliability.

- **Documentation**
  - Added Linux installation guidance for AppImage and package-manager options.

- **Release**
  - Updated the application version to **0.4.3-10006**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->