### PR TITLE
fix(windows): stop git subprocess console flash on Windows

### DIFF
--- a/public/native/session/session-sidebar.js
+++ b/public/native/session/session-sidebar.js
@@ -1090,12 +1090,23 @@ export class SessionSidebar {
         for (const pinned of pinnedGroups) {
           const ws = pinned.workspace;
           const workspaceId = ws?.path || `pinned-session:${pinned.sessions[0]?.id || ""}`;
+          const invoke = globalThis.__TAURI__?.core?.invoke ?? null;
+          const canCreateSession = Boolean(ws && !pinned.unavailable && invoke);
           const { group } = buildSidebarWorkspaceGroup({
             workspaceId,
             folderName: ws?.folderName || t("sidebar.unavailable"),
             workspacePath: ws?.path || "",
             sessionCount: pinned.sessions.length,
             expanded: true,
+            onNewChat: canCreateSession
+              ? () => {
+                  invoke("open_new_session_in_workspace", { projectPath: ws.path }).catch(
+                    (error) => {
+                      console.error("[Sidebar] Failed to start new chat:", error);
+                    },
+                  );
+                }
+              : null,
             onMoreActions: pinned.workspacePin
               ? (event) =>
                   this.#showProjectContextMenu(event, { path: ws.path, name: ws.folderName })

--- a/src-tauri/src/git_service.rs
+++ b/src-tauri/src/git_service.rs
@@ -1456,6 +1456,12 @@ fn git_command(root: &Path, args: impl IntoIterator<Item = OsString>) -> Command
             Ok(())
         });
     }
+    // CREATE_NO_WINDOW: keep console-less GUI children from flashing a window.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x0800_0000);
+    }
     command
 }
 fn git_os(root: &Path, args: &[OsString]) -> Result<Vec<u8>, String> {


### PR DESCRIPTION
## Summary
- `git_command()` in `src-tauri/src/git_service.rs` spawned `git` without `CREATE_NO_WINDOW` on Windows, so every background `git status`/`git diff` refresh (used heavily by the session sidebar) briefly flashed a console window. Added the same `creation_flags(0x0800_0000)` guard already used in `pi_launch.rs` and `native_pi_manager.rs`.
- `public/native/session/session-sidebar.js`: wired up a "new chat" action on pinned workspace groups, invoking `open_new_session_in_workspace` via Tauri when a workspace is available.

## Test plan
- [x] `cargo check` passes in `src-tauri`
- [ ] Manually verify on Windows that git-triggered sidebar refreshes no longer flash a console window
- [ ] Manually verify the new-chat button on pinned workspace groups starts a session