### PR TITLE
fix(windows): suppress console flash for all child process spawns

### DIFF
--- a/extensions/picot-config.ts
+++ b/extensions/picot-config.ts
@@ -1521,7 +1521,8 @@ function openExternal(url: string): void {
         ? ["cmd", ["/c", "start", "", url]]
         : ["xdg-open", [url]];
   try {
-    execFile(command, args, () => {});
+    // windowsHide: a console-less pi process would otherwise flash a cmd window.
+    execFile(command, args, { windowsHide: true }, () => {});
   } catch {
     // Best-effort; frontend falls back to window.open.
   }

--- a/src-tauri/src/git_pi_runner.rs
+++ b/src-tauri/src/git_pi_runner.rs
@@ -57,6 +57,7 @@ impl GitPiRunner {
     }
     pub fn command(binary: &Path, request_file: &Path, cwd: &Path) -> Command {
         let mut command = Command::new(binary);
+        crate::windows_child::hide_console(&mut command);
         command
             .current_dir(cwd)
             .arg("--system-prompt")

--- a/src-tauri/src/git_service.rs
+++ b/src-tauri/src/git_service.rs
@@ -1457,11 +1457,7 @@ fn git_command(root: &Path, args: impl IntoIterator<Item = OsString>) -> Command
         });
     }
     // CREATE_NO_WINDOW: keep console-less GUI children from flashing a window.
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        command.creation_flags(0x0800_0000);
-    }
+    crate::windows_child::hide_console(&mut command);
     command
 }
 fn git_os(root: &Path, args: &[OsString]) -> Result<Vec<u8>, String> {

--- a/src-tauri/src/host_data.rs
+++ b/src-tauri/src/host_data.rs
@@ -305,7 +305,9 @@ fn remove_session_file_trash_first_with(
 
 fn remove_session_file_trash_first(path: &std::path::Path) -> std::io::Result<()> {
     remove_session_file_trash_first_with(path, |target| {
-        std::process::Command::new("trash")
+        let mut command = std::process::Command::new("trash");
+        crate::windows_child::hide_console(&mut command);
+        command
             .arg(target)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
@@ -354,6 +356,7 @@ fn git_output(mut command: Command) -> Option<std::process::Output> {
 
 fn git_command_at(root: &Path) -> Command {
     let mut command = Command::new("git");
+    crate::windows_child::hide_console(&mut command);
     command
         .current_dir(root)
         .env("LC_ALL", "C")

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,6 +27,7 @@ mod terminal_profiles;
 mod terminal_registry;
 mod terminal_state_store;
 mod window_owner;
+mod windows_child;
 
 use host_server::HostServer;
 use metadata_store::MetadataStore;

--- a/src-tauri/src/markitdown_preview.rs
+++ b/src-tauri/src/markitdown_preview.rs
@@ -249,6 +249,7 @@ async fn run_bounded(
     include_path: bool,
 ) -> Option<(bool, String, String)> {
     let mut command = Command::new(executable);
+    crate::windows_child::hide_console_tokio(&mut command);
     command
         .args(args)
         .env_clear()

--- a/src-tauri/src/model_health.rs
+++ b/src-tauri/src/model_health.rs
@@ -99,6 +99,7 @@ pub async fn run_model_test(
     let (pi_bin, path_env) = pi_launch.resolve_bundled_pi_for_spawn()?;
 
     let mut command = Command::new(&pi_bin);
+    crate::windows_child::hide_console_tokio(&mut command);
     crate::appimage_env::scrub_tokio(&mut command);
     command
         .arg("--provider")

--- a/src-tauri/src/native_pi_manager.rs
+++ b/src-tauri/src/native_pi_manager.rs
@@ -115,7 +115,7 @@ impl NativePiManager {
     pub fn spawn(&self, target: RuntimeTarget, spec: NativeLaunchSpec) -> Result<(), String> {
         let launch = spec.command_description();
         let mut command = Command::new(&launch.program);
-        configure_child_process(&mut command);
+        crate::windows_child::hide_console(&mut command);
         // Before any of our own env: an AppImage's AppRun points the dynamic
         // loader at the bundle, and `pi` is built against the host system.
         crate::appimage_env::scrub(&mut command);
@@ -638,15 +638,6 @@ fn is_mutation(command_type: &str) -> bool {
             | "set_follow_up_mode"
     )
 }
-
-#[cfg(target_os = "windows")]
-fn configure_child_process(command: &mut Command) {
-    use std::os::windows::process::CommandExt;
-    command.creation_flags(0x0800_0000);
-}
-
-#[cfg(not(target_os = "windows"))]
-fn configure_child_process(_command: &mut Command) {}
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/package_updates.rs
+++ b/src-tauri/src/package_updates.rs
@@ -289,18 +289,22 @@ async fn run_update_command(command: &str, args: &[String], cwd: &Path) -> Resul
     }
     let output = timeout(
         Duration::from_secs(UPDATE_CHECK_TIMEOUT_SECS),
-        Command::new(command)
-            .args(args)
-            .current_dir(cwd)
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            // A per-subprocess timeout cancels the in-flight output() future, and a
-            // cancelled child that stays attached would keep running detached; always
-            // reap it on drop so stalled npm/git checks cannot leak orphan processes.
-            .kill_on_drop(true)
-            .output(),
+        {
+            let mut child = Command::new(command);
+            crate::windows_child::hide_console_tokio(&mut child);
+            child
+                .args(args)
+                .current_dir(cwd)
+                .env("GIT_TERMINAL_PROMPT", "0")
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                // A per-subprocess timeout cancels the in-flight output() future, and a
+                // cancelled child that stays attached would keep running detached; always
+                // reap it on drop so stalled npm/git checks cannot leak orphan processes.
+                .kill_on_drop(true)
+                .output()
+        },
     )
     .await
     .map_err(|_| "package update check timed out".to_string())?

--- a/src-tauri/src/pi_launch.rs
+++ b/src-tauri/src/pi_launch.rs
@@ -139,7 +139,7 @@ impl PiLaunchResolver {
         let pi_bin_str = strip_verbatim_prefix(&pi_bin.to_string_lossy());
         let augmented_path = build_augmented_path();
         let mut command = Command::new(&pi_bin_str);
-        configure_child_process_for_windows(&mut command);
+        crate::windows_child::hide_console(&mut command);
         crate::appimage_env::scrub(&mut command);
         command
             .args(args)
@@ -517,7 +517,9 @@ pub fn open_in_app(
     }
 
     if let Some(command) = command.map(str::trim).filter(|command| !command.is_empty()) {
-        let status = Command::new(command)
+        let mut launcher = Command::new(command);
+        crate::windows_child::hide_console(&mut launcher);
+        let status = launcher
             .arg(trimmed_path)
             .status()
             .map_err(|error| format!("Failed to launch `{command}`: {error}"))?;
@@ -538,7 +540,11 @@ pub fn open_in_app(
             .arg(trimmed_path)
             .status();
         #[cfg(not(target_os = "macos"))]
-        let status = Command::new(app_name).arg(trimmed_path).status();
+        let status = {
+            let mut launcher = Command::new(app_name);
+            crate::windows_child::hide_console(&mut launcher);
+            launcher.arg(trimmed_path).status()
+        };
 
         let status = status.map_err(|error| format!("Failed to open `{app_name}`: {error}"))?;
         if !status.success() {
@@ -556,7 +562,7 @@ fn open_path(path: &str) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     let status = {
         let mut command = Command::new("explorer");
-        configure_child_process_for_windows(&mut command);
+        crate::windows_child::hide_console(&mut command);
         command.arg(path).status()
     };
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
@@ -900,7 +906,7 @@ pub fn open_external(url: &str) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     let status = {
         let mut command = Command::new("cmd");
-        configure_child_process_for_windows(&mut command);
+        crate::windows_child::hide_console(&mut command);
         command.args(["/C", "start", "", trimmed]).status()
     };
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
@@ -911,16 +917,6 @@ pub fn open_external(url: &str) -> Result<(), String> {
         code => Err(format!("Opener exited with status {code}")),
     }
 }
-
-#[cfg(target_os = "windows")]
-fn configure_child_process_for_windows(command: &mut Command) {
-    use std::os::windows::process::CommandExt;
-    // CREATE_NO_WINDOW: keep console-less GUI children from flashing a window.
-    command.creation_flags(0x0800_0000);
-}
-
-#[cfg(not(target_os = "windows"))]
-fn configure_child_process_for_windows(_command: &mut Command) {}
 
 fn pi_extension_npm_bin_dir(home: &Path) -> PathBuf {
     home.join(".pi")

--- a/src-tauri/src/windows_child.rs
+++ b/src-tauri/src/windows_child.rs
@@ -1,0 +1,44 @@
+//! Suppress console windows for spawned children on Windows.
+//!
+//! Picot's release build is a GUI-subsystem binary (no console of its own).
+//! Windows gives every console child we spawn (git, node, npm, python, cmd)
+//! a brand-new, visible console window unless the `CREATE_NO_WINDOW` flag is
+//! passed to that one `CreateProcess` call — the flag is per-spawn and is not
+//! inherited by grandchildren. Those windows live exactly as long as the
+//! child runs, which is the "several terminal windows flashing randomly"
+//! reported in issue #39.
+//!
+//! Route every spawn through [`hide_console`] / [`hide_console_tokio`] the way
+//! spawns are routed through `appimage_env::scrub`, so the flag cannot be
+//! forgotten at a new call site.
+
+use std::process::Command as StdCommand;
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Hide the child's console window on Windows; no-op on other platforms.
+pub fn hide_console(command: &mut StdCommand) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = command;
+    }
+}
+
+/// tokio counterpart of [`hide_console`].
+pub fn hide_console_tokio(command: &mut tokio::process::Command) {
+    #[cfg(windows)]
+    {
+        // tokio::process::Command exposes creation_flags natively on Windows.
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = command;
+    }
+}


### PR DESCRIPTION
Fixes #39

The fix in 5706816 (CREATE_NO_WINDOW for git_service.rs) was incomplete — the issue still reproduces on that commit. Several other spawn sites run console children without the flag, so terminal windows keep flashing on Windows 11 while a pi session works. The noisiest one is the routine workspace git refresh in `host_data.rs` (`git status` / `stat` / `workspace-info` fire on every file-browser and project-header refresh).

## What changed
- Add `src-tauri/src/windows_child.rs` with shared `hide_console` / `hide_console_tokio` helpers
- Route every production spawn through them: `host_data.rs`, `git_pi_runner.rs`, `model_health.rs`, `package_updates.rs`, `markitdown_preview.rs`, `pi_launch.rs` (open_in_app) — folding in the three already-guarded sites and deleting their duplicated `configure_child_process*` helpers
- `windowsHide: true` for the picot-config extension's `cmd /C start` call

## Verification (Windows 11, GUI-subsystem process replicating the release build)
- 10 git spawns without the flag: **13 visible terminal windows flashed**; via the helper: **0**
- 20 spawns via the unfixed `host_data.rs` path at 5706816: 26 flashes; helper path: 0 (and ~5x faster — console-window creation is not free)
- `cargo test`: 186 passed / 20 failed, identical failure set to the unmodified tree on this machine (pre-existing Windows-only failures, unrelated to this change)