### PR TITLE
docs: note planned subagent/team support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Provide your model credentials via `pi /login` inside any workspace, or by writi
 - **Safe individual deletion** — delete a session from the sidebar or ARCHIVED; running sessions are refused by the server
 - **RECENT** — a cross-workspace, most-recently-used list keeps the last five visited sessions at the top of the sidebar
 
+> 🛣️ **Planned:** subagent/team support — spawning agent teams from the UI, visual grouping in the sidebar, and live-switching between agents. Tracked in [`ROADMAP.md`](./ROADMAP.md).
+
 **Full-text search** across all session history, with highlighted snippets (`⌘K`):
 
 <p align="center">

--- a/README.zh.md
+++ b/README.zh.md
@@ -111,6 +111,8 @@ curl -fsSL https://raw.githubusercontent.com/shixin-guo/picot/main/scripts/insta
 - **安全单条删除** — 可从侧边栏或「已归档」删除会话；运行中的会话会被服务端拒绝
 - **最近访问** — 跨工作区的最近使用列表固定显示最后访问的五个会话
 
+> 🛣️ **规划中：** subagent/团队支持 — 从界面中创建 Agent 团队、侧边栏可视化分组、Agent 间实时切换。详见 [`ROADMAP.md`](./ROADMAP.md)。
+
 **全文搜索** — 跨所有会话历史搜索并高亮匹配片段（`⌘K`）：
 
 <p align="center">


### PR DESCRIPTION
## Summary
- README currently has no mention that subagent/team support is planned; this was only tracked in `ROADMAP.md`.
- Add a short "Planned" callout in both `README.md` and `README.zh.md`, linking to the roadmap item, so readers don't mistake it for an already-shipped feature.

## Test plan
- [x] Docs-only change, no code affected
- [x] Verified links/anchors render correctly in Markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Xd5PNYi4NcXn4FHjaiZV3

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xd5PNYi4NcXn4FHjaiZV3)_